### PR TITLE
Add response body as last param of callback

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -172,6 +172,12 @@ Test.prototype.assert = function(res, fn){
     return fn(new Error('expected "' + field + '" of "' + expected + '", got "' + actual + '"'));
   }
 
-  fn(null, res);
+  // set res.body/res.text as last callback param
+  var resBody = res.text;
+  if ('object' == typeof res.body && !res.body instanceof RegExp) {
+    resBody = res.body;
+  }
+
+  fn(null, res, resBody);
 };
 

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -63,6 +63,34 @@ describe('request(app)', function(){
     .get('/')
     .expect(302, done);
   })
+  it('should expose a object body to expect callback', function(done){
+    var app = express();
+    app.set('json spaces', 0);
+    app.get('/', function(req, res){
+      res.send({foo: 'bar'});
+    });
+
+    request(app)
+    .get('/')
+    .expect(200, function(err, req, body) {
+      body.should.equal('{"foo":"bar"}')
+      done()
+    })
+  })
+  it('should expose a text body in expect callback', function(done){
+    var app = express();
+
+    app.get('/', function(req, res){
+      res.send('foo');
+    });
+
+    request(app)
+    .get('/')
+    .expect(200, function(err, req, body) {
+      body.should.equal('foo')
+      done()
+    })
+  })
 
   describe('.expect(status[, fn])', function(){
     it('should assert the response status', function(done){


### PR DESCRIPTION
Make the response body available in assertion callback:

``` js
request(app)
.get('/')
.expect(200, function(err, res, body) {
   assert.ok(body.something.etc)
})
```

Just for convenience, it's the most commonly accessed property of the response (at least in my use cases) and it matches up with mikeal's request module. Also thinking this may be handy in superagent (and perhaps should be implemented there first)
