### PR TITLE
corrected error in attach() example in readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -74,7 +74,7 @@ describe('GET /users', function(){
 ```js
 request(app)
 .post('/')
-.attach('test/fixtures/homeboy.jpg', 'avatar')
+.attach('avatar', 'test/fixtures/homeboy.jpg')
 ...
 ```
 


### PR DESCRIPTION
.attach() expects field name followed by filename
