### PR TITLE
add a test that doesn't pass an exception

### DIFF
--- a/test/supertest.js
+++ b/test/supertest.js
@@ -257,6 +257,20 @@ describe('request(app)', function(){
         done();
       });
     })
+
+    it('should assert response body multiple times with no exception', function(done){
+      var app = express();
+
+      app.get('/', function(req, res){
+        res.send('hey tj');
+      });
+
+      request(app)
+      .get('/')
+      .expect(/tj/)
+      .expect(/^hey/)
+      .expect('hey tj', done);
+    })
   })
 
   describe('.expect(field, value[, fn])', function(){


### PR DESCRIPTION
Add a test for @visionmedia 's comment on #37:

> "we should also add a test that doesn't pass an exception, to show that it does in fact work with multiple valid assertions"
