### PR TITLE
.expect(status) should assert only status

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -93,7 +93,7 @@ Test.prototype.expect = function(a, b, c){
   if ('number' == typeof a) {
     this._status = a;
     // body
-    if ('function' != typeof b) this._bodies.push(b);
+    if ('function' != typeof b && arguments.length > 1) this._bodies.push(b);
     return this;
   }
 
@@ -148,7 +148,7 @@ Test.prototype.assert = function(res, fn){
     var b = http.STATUS_CODES[res.status];
     return fn(new Error('expected ' + status + ' "' + a + '", got ' + res.status + ' "' + b + '"'), res);
   }
-  
+
   // body
   for (var i = 0; i < bodies.length; i++) {
     var body = bodies[i];

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -137,6 +137,21 @@ describe('request(app)', function(){
     })
   })
 
+  describe('.expect(status)', function () {
+    it('should assert only status', function (done) {
+      var app = express();
+
+      app.get('/', function (req, res) {
+        res.send('hey');
+      })
+
+      request(app)
+      .get('/')
+      .expect(200)
+      .end(done)
+    })
+  })
+
   describe('.expect(status, body[, fn])', function(){
     it('should assert the response body and status', function(done){
       var app = express();


### PR DESCRIPTION
Otherwise we have a gotcha:

``` javascript
.expect(200)
.end(function (err, res) {
  if (err) return done(err)  // currently yields expected body to be undefined
})
```
