### PR TITLE
Fixed redirect handling. Includes tests

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -121,6 +121,9 @@ Test.prototype.end = function(fn){
   var self = this;
   var end = Request.prototype.end;
   end.call(this, function(err, res){
+    if(err) {
+      return self.emit('error', err);
+    }
     self.assert(res, fn);
   });
   return this;


### PR DESCRIPTION
I was using supertest when developing the other day and realized that redirects could not be examined. This fixes that issue. 
