### PR TITLE
Bind to localhost only when start listening

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -62,7 +62,7 @@ Test.prototype.__proto__ = Request.prototype;
 Test.prototype.serverAddress = function(app, path){
   var addr = app.address();
   var portno = addr ? addr.port : port++;
-  if (!addr) app.listen(portno);
+  if (!addr) app.listen(portno, '127.0.0.1');
   var protocol = app instanceof https.Server ? 'https' : 'http';
   return protocol + '://127.0.0.1:' + portno + path;
 };


### PR DESCRIPTION
As we are relying on local URL scheme for testing anyway, there is no need to expose our test server to the world (at least when starting it ourselves).
