### PR TITLE
Use a random unused port.

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -14,7 +14,7 @@ var request = require('superagent')
  * Starting port.
  */
 
-var port = 3456;
+var port = 0;
 
 /**
  * Expose `Test`.
@@ -61,10 +61,10 @@ Test.prototype.__proto__ = Request.prototype;
 
 Test.prototype.serverAddress = function(app, path){
   var addr = app.address();
-  var portno = addr ? addr.port : port++;
-  if (!addr) app.listen(portno);
+  if (!addr) app.listen(0);
+  port = app.address().port
   var protocol = app instanceof https.Server ? 'https' : 'http';
-  return protocol + '://127.0.0.1:' + portno + path;
+  return protocol + '://127.0.0.1:' + port + path;
 };
 
 /**


### PR DESCRIPTION
In situations where supertest is run multiple times in parallel on the
same host EADDRINUSE can result. This is due to the current method of
using port 3456 (+ offset). A more reliable method for obtaining a
random unused port is to specify port 0 and have the OS choose which
port to bind.

Fixes #62
