### PR TITLE
Improve response body mismatch error message

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -7,7 +7,6 @@ var request = require('superagent')
   , util = require('util')
   , http = require('http')
   , https = require('https')
-  , assert = require('assert')
   , Request = request.Request;
 
 /**
@@ -15,6 +14,35 @@ var request = require('superagent')
  */
 
 var port = 3456;
+
+/**
+ * An implementation of deepEqual.
+ * If should or Chai are available, use them for better output.
+ */
+var deepEqual;
+[
+  ['should', function(module, a, b) { a.should.eql(b); }],
+  ['chai', function(module, a, b) { module.expect(a).to.eql(b); }],
+  ['assert', function(module, a, b) {
+    try {
+      module.deepEqual(a, b);
+    } catch (err) {
+      var astr = util.inspect(a, {depth: null});
+      var bstr = util.inspect(b, {depth: null});
+      throw new Error('expected ' + bstr + ' response body, got ' + astr);
+    }
+  }]
+].some(function(pair) {
+  var module, moduleDeepEqual = pair[1], moduleName = pair[0];
+  try {
+    module = require(moduleName);
+    deepEqual = moduleDeepEqual.bind(null, module);
+    return true;
+  } catch (err) {
+    // Module not available
+    return false;
+  }
+});
 
 /**
  * Expose `Test`.
@@ -156,11 +184,9 @@ Test.prototype.assert = function(res, fn){
     // parsed
     if ('object' == typeof body && !isregexp) {
       try {
-        assert.deepEqual(body, res.body);
+        deepEqual(res.body, body);
       } catch (err) {
-        var a = util.inspect(body);
-        var b = util.inspect(res.body);
-        return fn(new Error('expected ' + a + ' response body, got ' + b));
+        return fn(err);
       }
     } else {
       // string


### PR DESCRIPTION
**Reviewer Note:**  I realize this may not be something you're interested in supporting.  It has the down-side of changing behavior based on which modules are available.  But I have found it to improve the usefulness of supertest a lot for my use cases and thought you might want to consider it.

If the parsed response body does not match the expected value, the
current output is only really useful in cases where the difference is
readily apparent or the body is small and the difference is in the
outermost object or its child.  Otherwise the user may need to scroll
through large amounts of output and the mismatch may not be visible due
to the depth limit of util.inspect.

To make finding the source of inequality easier for users, make use of
either should or Chai assertions (which print very useful messages in
most test frameworks).  When neither should nor Chai is available,
include the entire object in the output to allow users to find the
inequality when it is not in the outermost object or its child.

Signed-off-by: Kevin Locke kevin@kevinlocke.name
