### PR TITLE
Close up listening servers after the tests

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -31,6 +31,7 @@ function Test(app, method, path) {
   this.redirects(0);
   this.buffer();
   this.app = app;
+  this._closeCleanup = false;
   this._fields = {};
   this._bodies = [];
   this.url = 'string' == typeof app
@@ -55,7 +56,10 @@ Test.prototype.__proto__ = Request.prototype;
 
 Test.prototype.serverAddress = function(app, path){
   var addr = app.address();
-  if (!addr) app.listen(0);
+  if (!addr) {
+    app.listen(0);
+    this._closeCleanup = true;
+  }
   var port = app.address().port;
   var protocol = app instanceof https.Server ? 'https' : 'http';
   return protocol + '://127.0.0.1:' + port + path;
@@ -118,8 +122,16 @@ Test.prototype.end = function(fn){
   end.call(this, function(err, res){
     if (err) return fn(err);
     self.assert(res, fn);
+    self.close()
   });
   return this;
+};
+
+Test.prototype.close = function(fn){
+  if (this._closeCleanup) {
+    this.app.close(fn);
+    return true;
+  } else { return false }
 };
 
 /**

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -58,7 +58,24 @@ describe('request(app)', function(){
     });
   })
 
-  it('should work with remote server', function(done){
+  it('should close down the server if it started it', function(done){
+    var app = express();
+
+    app.get('/', function(req, res){
+      res.send('hey');
+    });
+
+
+    var testReq = request(app)
+    .get('/')
+    .end(function(err, res){
+      res.should.have.status(200);
+      res.text.should.equal('hey');
+    });
+    testReq.app.on('close', function(){done();});
+  })
+
+  it('should not close down an already started server', function(done){
     var app = express();
 
     app.get('/', function(req, res){
@@ -66,7 +83,27 @@ describe('request(app)', function(){
     });
 
     var server = app.listen(4001, function(){
-      request('http://localhost:4001')
+      var testReq = request(server)
+      .get('/')
+      .end(function(err, res){
+        res.should.have.status(200);
+        res.text.should.equal('hey');
+        testReq.close().should.be.false;
+        done();
+      });
+    });
+
+  })
+
+  it('should work with remote server', function(done){
+    var app = express();
+
+    app.get('/', function(req, res){
+      res.send('hey');
+    });
+
+    var server = app.listen(4002, function(){
+      request('http://localhost:4002')
       .get('/')
       .end(function(err, res){
         res.should.have.status(200);


### PR DESCRIPTION
If we open up a ephemeral port to test on, at the end of the test we
should close it up.

Apparently I deleted the other branch by mistake on https://github.com/visionmedia/supertest/pull/51, and nothing got merged in.
