### PR TITLE
Pass `this` to end() callbacks

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -191,7 +191,7 @@ Test.prototype.assert = function(res, fn){
     }
   }
 
-  fn(null, res);
+  fn.call(this, null, res);
 };
 
 /**

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -21,6 +21,21 @@ describe('request(url)', function(){
       .expect("hello", done);
     });
   })
+
+  describe('.end(cb)', function() {
+    it('should set `this` to the test object when calling cb', function(done) {
+      var app = express();
+
+      var s = app.listen(function(){
+        var url = 'http://localhost:' + s.address().port;
+        var test = request(url).get('/');
+        test.end(function(err, res) {
+          this.should.eql(test);
+          done();
+        });
+      });
+    })
+  })
 })
 
 describe('request(app)', function(){


### PR DESCRIPTION
The change allows developer to access the `Test` object and its properties like `url` from the callback passed to `.end()`. This is useful when the request URL is constructed dynamically using a random server port.

Example:

```
request(app)
  .get('/foo/bar')
  .end(function(err, res) {
    if (err) return done(err);
    var remoteOrigin = url.resolve(this.url, '/');
    res.body.originUrl.should.eql(remoteOrigin);
  });
```
