### PR TITLE
add expect(function(res) {}) syntax

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -117,6 +117,24 @@ request.get('/').expect('heya', function(err){
 
   Assert header `field` `value` with a string or regular expression.
 
+### .expect(function(res) {})
+
+  Pass a custom assertion function. It'll be given the response object to check. If the response is ok, it should return falsy, most commonly by not returning anything. If the check fails, throw an error or return a truthy value like a string that'll be turned into an error. 
+
+  Here the string or error throwing options are both demonstrated:
+
+  ```js
+  request(app)
+    .get('/')
+    .expect(hasPreviousAndNextKeys)
+    .end(done);
+
+  function hasPreviousAndNextKeys(res) {
+    if (!('next' in res.body)) return "missing next key";
+    if (!('prev' in res.body)) throw new Error("missing prev key");
+  }
+  ```
+
 ### .end(fn)
 
   Perform the request and invoke `fn(err, res)`.

--- a/lib/test.js
+++ b/lib/test.js
@@ -33,6 +33,7 @@ function Test(app, method, path) {
   this.app = app;
   this._fields = {};
   this._bodies = [];
+  this._asserts = [];
   this.url = 'string' == typeof app
     ? app + path
     : this.serverAddress(app, path);
@@ -71,6 +72,7 @@ Test.prototype.serverAddress = function(app, path){
  *   .expect('Some body', fn)
  *   .expect('Content-Type', 'application/json')
  *   .expect('Content-Type', 'application/json', fn)
+ *   .expect(fn)
  *
  * @return {Test}
  * @api public
@@ -80,6 +82,10 @@ Test.prototype.expect = function(a, b, c){
   var self = this;
 
   // callback
+  if ('function' == typeof a) {
+    this._asserts.push(a);
+    return this;
+  }
   if ('function' == typeof b) this.end(b);
   if ('function' == typeof c) this.end(c);
 
@@ -189,6 +195,19 @@ Test.prototype.assert = function(res, fn){
       if (re) return fn(new Error('expected "' + field + '" matching ' + fieldExpected + ', got "' + actual + '"'));
       return fn(new Error('expected "' + field + '" of "' + fieldExpected + '", got "' + actual + '"'));
     }
+  }
+
+  // asserts
+  for (var i = 0; i < this._asserts.length; i++) {
+    var check = this._asserts[i];
+    var err;
+    try {
+      err = check(res);
+    } catch(e) {
+      err = e;
+    }
+    if (!err) continue;
+    return fn(err instanceof Error ? err : new Error(err))
   }
 
   fn.call(this, null, res);


### PR DESCRIPTION
Adding the ability for `expect()` pass custom assertion functions 
makes it easy to create reusable assertions (and simple plugins).

For instance, an API might require a certain content-type and 'next' 
and 'previous' keys in a number of endpoints. With the ability to pass in an
assertion function this use-case becomes very simple:

```
request(app).get('/').expect(validPagedApiResponse).end(done);

function validPagedApiResponse(res) {
  if(!('next' in res.body)) return "All responses require a 'next'
  key";
  // etc, lots of extra testing we can now apply in a single line
}
```
