### PR TITLE
Added check fields.hasOwnProperty(field)

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -178,16 +178,18 @@ Test.prototype.assert = function(res, fn){
 
   // fields
   for (var field in fields) {
-    expecteds = fields[field];
-    actual = res.header[field.toLowerCase()];
-    if (null == actual) return fn(new Error('expected "' + field + '" header field'));
-    for (var i = 0; i < expecteds.length; i++) {
-      var fieldExpected = expecteds[i];
-      if (fieldExpected == actual) continue;
-      if (fieldExpected instanceof RegExp) re = fieldExpected;
-      if (re && re.test(actual)) continue;
-      if (re) return fn(new Error('expected "' + field + '" matching ' + fieldExpected + ', got "' + actual + '"'));
-      return fn(new Error('expected "' + field + '" of "' + fieldExpected + '", got "' + actual + '"'));
+    if (fields.hasOwnProperty(field)) {
+      expecteds = fields[field];
+      actual = res.header[field.toLowerCase()];
+      if (null == actual) return fn(new Error('expected "' + field + '" header field'));
+      for (var i = 0; i < expecteds.length; i++) {
+        var fieldExpected = expecteds[i];
+        if (fieldExpected == actual) continue;
+        if (fieldExpected instanceof RegExp) re = fieldExpected;
+        if (re && re.test(actual)) continue;
+        if (re) return fn(new Error('expected "' + field + '" matching ' + fieldExpected + ', got "' + actual + '"'));
+        return fn(new Error('expected "' + field + '" of "' + fieldExpected + '", got "' + actual + '"'));
+      }
     }
   }
 


### PR DESCRIPTION
Hi everyone,

I added additional check for object's own property, so the test logic skips inherited values for `Test._fields = {}` 

``` JavaScript
  // fields
  for (var field in fields) {
    if (fields.hasOwnProperty(field)) {
    // logic code here
    }
  }
```

In cases when Javascript `Object` type is extended with custom fields/methods, for example:

``` JavaScript
Object.prototype.andCheck = function () {
  actual++;
}
```

`supertest`'s `lib/test.js:183` throws errors like:

``` JavasScript
Error: expected "andCheck" header field
```

In my case it happened when I tried to use `supertest` with Mocha and [Assertion counting](https://github.com/visionmedia/mocha/wiki/Assertion-counting)
