### PR TITLE
ignore cert errors for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 test:
-	@./node_modules/.bin/mocha \
+	@NODE_TLS_REJECT_UNAUTHORIZED=0 ./node_modules/.bin/mocha \
 		--require should \
 		--reporter spec
 


### PR DESCRIPTION
@visionmedia just wanted to double check before committing if you see an issue with this. It will keep travis-ci quiet on `>= 0.10.x` and remove the need to keep up with the dev certs.
