### PR TITLE
Allow numbers to be used for asserting headers

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -98,7 +98,7 @@ Test.prototype.expect = function(a, b, c){
   }
 
   // header field
-  if ('string' == typeof b || b instanceof RegExp) {
+  if ('string' == typeof b || 'number' == typeof b || b instanceof RegExp) {
     if (!this._fields[a]) this._fields[a] = [];
     this._fields[a].push(b);
     return this;

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -400,6 +400,22 @@ describe('request(app)', function(){
       });
     })
 
+    it('should support numbers', function(done){
+      var app = express();
+
+      app.get('/', function(req, res){
+        res.send('hey');
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Length', 4)
+      .end(function(err){
+        err.message.should.equal('expected "Content-Length" of "4", got "3"');
+        done();
+      });
+    })
+
     describe('handling arbitrary expect functions', function(){
       it('reports errors',function(done) {
         var app = express();


### PR DESCRIPTION
Hi. First off thanks for making this module. Makes testing web app routes easy to test.

This change allows a number to be used as the second parameter (value) when asserting headers using expect()

e.g. expect('Content-Length', 20)

I ran into this problem when I was passing string.length for the content length and was getting a confusing error message (`[Error: expected 'Content-Length' response body, got 'Z9ASMVNVDM']`) because I couldn't understand why supertest was expecting 'Content-Length' in the body.
