### PR TITLE
close http.Server after test ended

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -34,6 +33,7 @@ function Test(app, method, path) {
   this._fields = {};
   this._bodies = [];
   this._asserts = [];
+  this._server = null;
   this.url = 'string' == typeof app
     ? app + path
     : this.serverAddress(app, path);
@@ -56,7 +56,7 @@ Test.prototype.__proto__ = Request.prototype;
 
 Test.prototype.serverAddress = function(app, path){
   var addr = app.address();
-  if (!addr) app.listen(0);
+  if (!addr) this.server = app.listen(0);
   var port = app.address().port;
   var protocol = app instanceof https.Server ? 'https' : 'http';
   return protocol + '://127.0.0.1:' + port + path;
@@ -124,6 +124,7 @@ Test.prototype.end = function(fn){
   end.call(this, function(err, res){
     if (err) return fn(err);
     self.assert(res, fn);
+    if (self.server) self.server.close();
   });
   return this;
 };


### PR DESCRIPTION
running  > 100 tests using supertest I had the problem that the socket hang up.

Error: socket hang up
      at createHangUpError (http.js:1442:15)
      at Socket.socketOnEnd [as onend](http.js:1538:23)
      at Socket.g (events.js:175:14)
      at Socket.EventEmitter.emit (events.js:117:20)
      at _stream_readable.js:910:16
      at process._tickCallback (node.js:415:13)

to prevent this without to increase the kern.maxfiles and kern.maxfilesperproc I have to close the opened http.Server after the test ended.
