### PR TITLE
Support for .delete()

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,14 +21,13 @@ module.exports = function(app){
   var obj = {};
 
   methods.forEach(function(method){
-    var name = 'delete' == method
-      ? 'del'
-      : method;
-
-    obj[name] = function(url){
+    obj[method] = function(url){
       return new Test(app, method, url);
     };
   });
+
+  // Support previous use of del
+  obj.del = obj.delete;
 
   return obj;
 };

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -16,7 +16,7 @@ module.exports = TestAgent;
 
 /**
  * Initialize a new `TestAgent`.
- * 
+ *
  * @param {Function|Server} app
  * @api public
  */
@@ -35,13 +35,9 @@ function TestAgent(app){
 TestAgent.prototype.__proto__ = Agent.prototype;
 
 // override HTTP verb methods
-
 methods.forEach(function(method){
-  var name = 'delete' == method ? 'del' : method;
-
-  method = method.toUpperCase();
-  TestAgent.prototype[name] = function(url, fn){
-    var req = new Test(this.app, method, url);
+  TestAgent.prototype[method] = function(url, fn){
+    var req = new Test(this.app, method.toUpperCase(), url);
 
     req.on('response', this.saveCookies.bind(this));
     req.on('redirect', this.saveCookies.bind(this));
@@ -51,3 +47,5 @@ methods.forEach(function(method){
     return req;
   };
 });
+
+TestAgent.prototype.del = TestAgent.prototype.delete;

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -653,3 +653,55 @@ describe('request.agent(app)', function(){
   })
 })
 
+describe(".<http verb> works as expected", function(){
+    it(".delete should work", function (done){
+        var app = express();
+        app.delete('/', function(req, res){
+          res.send(200);
+        });
+
+        request(app)
+        .del('/')
+        .expect(200, done);
+    });
+    it(".del should still work", function (done){
+        var app = express();
+        app.del('/', function(req, res){
+          res.send(200);
+        });
+
+        request(app)
+        .del('/')
+        .expect(200, done);
+    });
+    it(".get should work", function (done){
+        var app = express();
+        app.get('/', function(req, res){
+          res.send(200);
+        });
+
+        request(app)
+        .get('/')
+        .expect(200, done);
+    });
+    it(".post should work", function (done){
+        var app = express();
+        app.post('/', function(req, res){
+          res.send(200);
+        });
+
+        request(app)
+        .post('/')
+        .expect(200, done);
+    });
+    it(".put should work", function (done){
+        var app = express();
+        app.put('/', function(req, res){
+          res.send(200);
+        });
+
+        request(app)
+        .put('/')
+        .expect(200, done);
+    });
+});


### PR DESCRIPTION
Previously supertest was renaming .delete() to .del(). This pull request changes it to use .delete() along with still supporting the .del() as to not break existing things.

Added unit tests, verified both function as expected and even included it into my existing test project. Let me know if this works or if there was an explicit reason, not covered by the unit tests, as to why del was originally used that I missed.
