### PR TITLE
.end: wait for server to close before invoking callback

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -121,9 +121,12 @@ Test.prototype.end = function(fn){
   var self = this;
   var end = Request.prototype.end;
   end.call(this, function(err, res){
+    function assert(){
+      self.assert(res, fn);
+    }
     if (err) return fn(err);
-    self.assert(res, fn);
-    if (self._server) self._server.close();
+    if (self._server) return self._server.close(assert);
+    assert();
   });
   return this;
 };

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -184,6 +184,48 @@ describe('request(app)', function(){
         done();
       });
     });
+
+    it('should wait for server to close before invoking fn', function(done){
+      var app = express();
+      var closed = false;
+
+      app.get('/', function(req, res){
+        res.send('supertest FTW!');
+      });
+
+      test = request(app)
+      .get('/')
+      .end(function(){
+        closed.should.be.true;
+        done();
+      });
+
+      test._server.on('close', function(){
+        closed = true;
+      });
+    });
+
+    it('should support nested requests', function(done){
+      var app = express();
+      var test = request(app);
+
+      app.get('/', function(req, res){
+        res.send('supertest FTW!');
+      });
+
+      test
+      .get('/')
+      .end(function(){
+        test
+        .get('/')
+        .end(function(err, res){
+          (err === null).should.be.true;
+          res.should.have.status(200);
+          res.text.should.equal('supertest FTW!');
+          done();
+        });
+      });
+    });
   });
 
   describe('.expect(status[, fn])', function(){


### PR DESCRIPTION
If a server was spawned, wait for it to close before invoking .end's
callback. This allows the callback to launch another request against the
same supertest object without receiving a connection error.

Fixes #126.
