### PR TITLE
Fix:   .end wasnt getting the res passed if assertion fails

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -163,7 +163,7 @@ Test.prototype.assert = function(res, fn){
       } catch (err) {
         var a = util.inspect(body);
         var b = util.inspect(res.body);
-        return fn(error('expected ' + a + ' response body, got ' + b, body, res.body));
+        return fn(error('expected ' + a + ' response body, got ' + b, body, res.body),res);
       }
     } else {
       // string
@@ -174,10 +174,10 @@ Test.prototype.assert = function(res, fn){
         // regexp
         if (isregexp) {
           if (!body.test(res.text)) {
-            return fn(error('expected body ' + b + ' to match ' + body, body, res.body));
+            return fn(error('expected body ' + b + ' to match ' + body, body, res.body),res);
           }
         } else {
-          return fn(error('expected ' + a + ' response body, got ' + b, body, res.body));
+          return fn(error('expected ' + a + ' response body, got ' + b, body, res.body),res);
         }
       }
     }
@@ -193,8 +193,8 @@ Test.prototype.assert = function(res, fn){
       if (fieldExpected == actual) continue;
       if (fieldExpected instanceof RegExp) re = fieldExpected;
       if (re && re.test(actual)) continue;
-      if (re) return fn(new Error('expected "' + field + '" matching ' + fieldExpected + ', got "' + actual + '"'));
-      return fn(new Error('expected "' + field + '" of "' + fieldExpected + '", got "' + actual + '"'));
+      if (re) return fn(new Error('expected "' + field + '" matching ' + fieldExpected + ', got "' + actual + '"'),res);
+      return fn(new Error('expected "' + field + '" of "' + fieldExpected + '", got "' + actual + '"'),res);
     }
   }
 
@@ -215,7 +215,7 @@ Test.prototype.assert = function(res, fn){
       err = e;
     }
     if (!err) continue;
-    return fn(err instanceof Error ? err : new Error(err))
+    return fn(err instanceof Error ? err,res : new Error(err),res)
   }
 
   fn.call(this, null, res);

--- a/lib/test.js
+++ b/lib/test.js
@@ -215,7 +215,8 @@ Test.prototype.assert = function(res, fn){
       err = e;
     }
     if (!err) continue;
-    return fn(err instanceof Error ? err,res : new Error(err),res)
+	if (err instanceof Error) return fn(err, res);
+                         else return fn(new Error(err),res);
   }
 
   fn.call(this, null, res);


### PR DESCRIPTION
This basically just ensures that res is passed properly into .end if any assertions fail in the supertest expects.

