### PR TITLE
Changed end() to return a Promise when called without arguments.

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -122,6 +122,15 @@ Test.prototype.end = function(fn){
   var server = this._server;
   var end = Request.prototype.end;
 
+  if (!fn) {
+    return new Promise(function (resolve, reject) {
+      self.end(function (err, res) {
+        if (err) { return reject(err); }
+        resolve(res);
+      });
+    });
+  }
+
   end.call(this, function(err, res){
     if (err) return fn(err);
     if (server) return server.close(assert);

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "methods": "1.1.0"
   },
   "devDependencies": {
+    "es6-promise": "1.0.0",
     "express": "3.1.0",
     "mocha": "1.19.0",
     "should": "3.3.1"

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -1,3 +1,4 @@
+require('es6-promise').polyfill();
 
 var request = require('..')
   , https = require('https')
@@ -225,6 +226,21 @@ describe('request(app)', function(){
           done();
         });
       });
+    });
+  });
+
+  describe('.end()', function() {
+    it('should return a promise of the callback', function() {
+      var app = express();
+      var test = request(app);
+
+      app.get('/', function(req, res){
+        res.send('supertest FTW!');
+      });
+
+      return test
+        .get('/')
+        .end();
     });
   });
 


### PR DESCRIPTION
This is a pretty handy thing to have, especially with Mocha, allowing you to go from this (example from supertest's own tests):

``` javascript
it('should support nested requests', function(done){
  var app = express();
  var test = request(app);

  app.get('/', function(req, res){
    res.send('supertest FTW!');
  });

  test
  .get('/')
  .end(function(){
    test
    .get('/')
    .end(function(err, res){
      (err === null).should.be.true;
      res.should.have.status(200);
      res.text.should.equal('supertest FTW!');
      done();
    });
  });
});
```

to this:

``` javascript
it('should support nested requests', function(){
  var app = express();
  var test = request(app);

  app.get('/', function(req, res){
    res.send('supertest FTW!');
  });

  return test
  .get('/')
  .end()
  .then(function (res) {
    return test
    .get('/')
    .end();
  }).then(function (res) {
    res.should.have.status(200);
    res.text.should.equal('supertest FTW!');
  });
});
```

Or, in a simpler case, the boilerplate reduction is even more obvious:

``` javascript
it('should do something', function (done) {
  request(app)
  .get('/')
  .expect(200)
  .end(function (err, res) {
    if (err) { return done(err); }
    done();
  });
});
```

vs

``` javascript
it('should do something', function(){
  return request(app)
  .get('/')
  .expect(200)
  .end();
});
```

Do note that this depends on ES6 Promises so it works only on node 0.11.x and later, but the `es6-promise` polyfill can be used for older versions.
