### PR TITLE
Added options param with option to start https server

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = function(app, options){
   options = options || {};
   if ('function' == typeof app) {
     if (options.https) {
-      app = https.createServer(app);
+      app = https.createServer({key: options.key, cert: options.cert}, app);
     } else {
       app = http.createServer(app);
     }


### PR DESCRIPTION
We had some tests that would only work when the server is running https mode so I added an options param which when https is true and key / cert are passed it will start the server as https.
