### PR TITLE
upgrade superagent to 0.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "superagent": "0.18.0",
+    "superagent": "0.19.0",
     "methods": "1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
superagent 0.18.0 requires qs 0.6.6, this has a known vulnerability (https://nodesecurity.io/advisories/qs_dos_extended_event_loop_blocking). superagent 0.19.0 updates qs to 1.2.0, fixing this vulnerability.
