### PR TITLE
Add a new option to force 'localhost' as hostname instead of local ip

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,13 +16,13 @@ var methods = require('methods')
  * @api public
  */
 
-module.exports = function(app){
+module.exports = function(app, options){
   if ('function' == typeof app) app = http.createServer(app);
   var obj = {};
 
   methods.forEach(function(method){
     obj[method] = function(url){
-      return new Test(app, method, url);
+      return new Test(app, method, url, options);
     };
   });
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -25,7 +25,7 @@ module.exports = Test;
  * @api public
  */
 
-function Test(app, method, path) {
+function Test(app, method, path, options) {
   Request.call(this, method, path);
   this.redirects(0);
   this.buffer();
@@ -33,6 +33,7 @@ function Test(app, method, path) {
   this._fields = {};
   this._bodies = [];
   this._asserts = [];
+  this._options = options || {};
   this.url = 'string' == typeof app
     ? app + path
     : this.serverAddress(app, path);
@@ -58,7 +59,8 @@ Test.prototype.serverAddress = function(app, path){
   if (!addr) this._server = app.listen(0);
   var port = app.address().port;
   var protocol = app instanceof https.Server ? 'https' : 'http';
-  return protocol + '://127.0.0.1:' + port + path;
+  var hostname = this._options.isLocalhost ? 'localhost': '127.0.0.1';
+  return protocol + '://' + hostname + ':' + port + path;
 };
 
 /**


### PR DESCRIPTION
For configuration reasons, I cannot use the local ip "127.0.0.1" to run my tests. So I added a new option to use "localhost" instead of "127.0.0.1" if any.
