### PR TITLE
Fix first sample in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,13 +23,13 @@ var request = require('supertest')
 var app = express();
 
 app.get('/user', function(req, res){
-  res.send(200, { name: 'tobi' });
+  res.status(200).send({ name: 'tobi' });
 });
 
 request(app)
   .get('/user')
   .expect('Content-Type', /json/)
-  .expect('Content-Length', '20')
+  .expect('Content-Length', '15')
   .expect(200)
   .end(function(err, res){
     if (err) throw err;


### PR DESCRIPTION
Line 26 was `res.send(200, {...})` but would give this warning when running:
`express deprecated res.send(status, body): Use res.status(status).send(body) instead`

Line 32 was `.expect('Content-Length', '15')` but it gave me an error:
`Error: expected "Content-Length" matching 20, got "15"`

I've fixed those.

(using Express 4.10.3)