### PR TITLE
Fix 4th sample in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -97,18 +97,15 @@ request.get('/').expect('heya', function(err){
 
 ```js
 var request = require('supertest')
-   , should = require('should')
-   , express = require('express');
+   , assert = require('assert')
+   , express = require('express')
+   , cookieParser = require('cookie-parser');
 
   
- var app = express(); 
-  app.use(express.cookieParser());
-
-
 describe('request.agent(app)', function(){
   var app = express();
 
-  app.use(express.cookieParser());
+  app.use(cookieParser());
 
   app.get('/', function(req, res){
     res.cookie('cookie', 'hey');


### PR DESCRIPTION
I don't think `should` is included in `mocha`, but I guess you know that since [should.js](https://github.com/tj/should.js) is on your username. :P Anyway, running the sample gave me `Error: Cannot find module 'should'` which was annoying. Simply replacing the word "should" with "assert" fixed it so I thought that's better consistency.

The next error was cookie parser:
`Error: Most middleware (like cookieParser) is no longer bundled with Express and must be installed separately. Please see https://github.com/senchalabs/connect#middleware.`

Lastly, `app` was defined twice and the first one on global scope didn't seem needed so I removed that.

This PR fixes all those things.

(again, using latest Express, 4.10.3)