### PR TITLE
Change assertion order: status, then headers, then body

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -152,6 +152,28 @@ Test.prototype.assert = function(res, fn){
     , actual
     , re;
 
+  // status
+  if (status && res.status !== status) {
+    var a = http.STATUS_CODES[status];
+    var b = http.STATUS_CODES[res.status];
+    return fn(new Error('expected ' + status + ' "' + a + '", got ' + res.status + ' "' + b + '"'), res);
+  }
+
+  // fields
+  for (var field in fields) {
+    expecteds = fields[field];
+    actual = res.header[field.toLowerCase()];
+    if (null == actual) return fn(new Error('expected "' + field + '" header field'));
+    for (var i = 0; i < expecteds.length; i++) {
+      var fieldExpected = expecteds[i];
+      if (fieldExpected == actual) continue;
+      if (fieldExpected instanceof RegExp) re = fieldExpected;
+      if (re && re.test(actual)) continue;
+      if (re) return fn(new Error('expected "' + field + '" matching ' + fieldExpected + ', got "' + actual + '"'));
+      return fn(new Error('expected "' + field + '" of "' + fieldExpected + '", got "' + actual + '"'));
+    }
+  }
+
   // body
   for (var i = 0; i < bodies.length; i++) {
     var body = bodies[i];
@@ -181,28 +203,6 @@ Test.prototype.assert = function(res, fn){
         }
       }
     }
-  }
-
-  // fields
-  for (var field in fields) {
-    expecteds = fields[field];
-    actual = res.header[field.toLowerCase()];
-    if (null == actual) return fn(new Error('expected "' + field + '" header field'));
-    for (var i = 0; i < expecteds.length; i++) {
-      var fieldExpected = expecteds[i];
-      if (fieldExpected == actual) continue;
-      if (fieldExpected instanceof RegExp) re = fieldExpected;
-      if (re && re.test(actual)) continue;
-      if (re) return fn(new Error('expected "' + field + '" matching ' + fieldExpected + ', got "' + actual + '"'));
-      return fn(new Error('expected "' + field + '" of "' + fieldExpected + '", got "' + actual + '"'));
-    }
-  }
-
-  // status
-  if (status && res.status !== status) {
-    var a = http.STATUS_CODES[status];
-    var b = http.STATUS_CODES[res.status];
-    return fn(new Error('expected ' + status + ' "' + a + '", got ' + res.status + ' "' + b + '"'), res);
   }
 
   // asserts
@@ -238,4 +238,3 @@ function error(msg, expected, actual) {
   err.showDiff = true;
   return err;
 }
-

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -312,7 +312,7 @@ describe('request(app)', function(){
       });
     })
 
-    it('should assert the body before the status', function (done) {
+    it('should assert the status before the body', function (done) {
       var app = express();
 
       app.set('json spaces', 0);
@@ -326,7 +326,7 @@ describe('request(app)', function(){
       .expect(200)
       .expect('hey')
       .end(function(err, res){
-        err.message.should.equal('expected \'hey\' response body, got \'{"message":"something went wrong"}\'');
+        err.message.should.equal('expected 200 \"OK\", got 500 \"Internal Server Error\"');
         done();
       });
     });


### PR DESCRIPTION
Currently, supertest checks the body first, then the headers and finally the status code. This results in uninformative error messages.

### Example

Current output:

``` patch
Error: expected { id: 'fcbf5cc4-f68e-45b7-98cb-5aae7d9dc071',
source: { owner: 'alice', amount: '10' } } response body, got {}
  + expected - actual

+{
+  "id": "fcbf5cc4-f68e-45b7-98cb-5aae7d9dc071"
+  "source": {
+    "amount": "10"
+    "owner": "alice"
+  }
+}
-{}
```

What's happening here? Maybe there is some bug in the database logic that causes the database to return an empty object?

After this pull request:

``` patch
Error: expected 201 "Created", got 404 "Not Found"
```

It is suddenly much clearer what happened: it never got that far, the problem is that the route doesn't even exist. The status code is *coarser* and should therefore be tested first.

### Rationale

The status code defines the overall success or failure of the request, so it should be checked before more detailed properties of the request are examined.

The headers specify the content type, so they should be checked before any attempt to interpret/validate the body.

This also corresponds to the order that these things actually appear in in the HTTP response on the wire.

### See also

#173