### PR TITLE
Do assertions dependant on call order

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -33,6 +33,7 @@ function Test(app, method, path) {
   this._fields = {};
   this._bodies = [];
   this._asserts = [];
+  this._expectStack = [];
   this.url = 'string' == typeof app
     ? app + path
     : this.serverAddress(app, path);
@@ -76,8 +77,23 @@ Test.prototype.serverAddress = function(app, path){
  * @return {Test}
  * @api public
  */
+Test.prototype.expect = function(a, b, c) {
+  'use strict';
 
-Test.prototype.expect = function(a, b, c){
+  var args = [a];
+  if (b !== undefined) args.push(b);
+  if (c !== undefined) args.push(c);
+
+  this._expectStack.push(args);
+
+  if ('function' == typeof b) this.end(b);
+  if ('function' == typeof c) this.end(c);
+
+  return this;
+};
+
+
+Test.prototype._expect = function(a, b, c){
   var self = this;
 
   // callback
@@ -85,8 +101,6 @@ Test.prototype.expect = function(a, b, c){
     this._asserts.push(a);
     return this;
   }
-  if ('function' == typeof b) this.end(b);
-  if ('function' == typeof c) this.end(c);
 
   // status
   if ('number' == typeof a) {
@@ -144,62 +158,75 @@ Test.prototype.end = function(fn){
  */
 
 Test.prototype.assert = function(resError, res, fn){
-  var status = this._status
-    , fields = this._fields
-    , bodies = this._bodies
+  var status
+    , fields
+    , bodies
     , expecteds
     , actual
     , re;
 
-  // body
-  for (var i = 0; i < bodies.length; i++) {
-    var body = bodies[i];
-    var isregexp = body instanceof RegExp;
-    // parsed
-    if ('object' == typeof body && !isregexp) {
-      try {
-        assert.deepEqual(body, res.body);
-      } catch (err) {
-        var a = util.inspect(body);
-        var b = util.inspect(res.body);
-        return fn(error('expected ' + a + ' response body, got ' + b, body, res.body), res);
-      }
-    } else {
-      // string
-      if (body !== res.text) {
-        var a = util.inspect(body);
-        var b = util.inspect(res.text);
+  while(this._expectStack.length) {
+    this._status = undefined;
+    this._fields = {};
+    this._bodies = [];
+    this._asserts = [];
 
-        // regexp
-        if (isregexp) {
-          if (!body.test(res.text)) {
-            return fn(error('expected body ' + b + ' to match ' + body, body, res.body), res);
+    this._expect.apply(this, this._expectStack.shift());
+
+    status = this._status;
+    fields = this._fields;
+    bodies = this._bodies;
+
+
+    // body
+    for (var i = 0; i < bodies.length; i++) {
+      var body = bodies[i];
+      var isregexp = body instanceof RegExp;
+      // parsed
+      if ('object' == typeof body && !isregexp) {
+        try {
+          assert.deepEqual(body, res.body);
+        } catch (err) {
+          var a = util.inspect(body);
+          var b = util.inspect(res.body);
+          return fn(error('expected ' + a + ' response body, got ' + b, body, res.body));
+        }
+      } else {
+        // string
+        if (body !== res.text) {
+          var a = util.inspect(body);
+          var b = util.inspect(res.text);
+
+          // regexp
+          if (isregexp) {
+            if (!body.test(res.text)) {
+              return fn(error('expected body ' + b + ' to match ' + body, body, res.body));
+            }
+          } else {
+            return fn(error('expected ' + a + ' response body, got ' + b, body, res.body));
           }
-        } else {
-          return fn(error('expected ' + a + ' response body, got ' + b, body, res.body), res);
         }
       }
     }
-  }
 
-  // fields
-  for (var field in fields) {
-    expecteds = fields[field];
-    actual = res.header[field.toLowerCase()];
-    if (null == actual) return fn(new Error('expected "' + field + '" header field'), res);
-    for (var i = 0; i < expecteds.length; i++) {
-      var fieldExpected = expecteds[i];
-      if (fieldExpected == actual) continue;
-      if (fieldExpected instanceof RegExp) re = fieldExpected;
-      if (re && re.test(actual)) continue;
-      if (re) return fn(new Error('expected "' + field + '" matching ' + fieldExpected + ', got "' + actual + '"'), res);
-      return fn(new Error('expected "' + field + '" of "' + fieldExpected + '", got "' + actual + '"'), res);
+
+    // fields
+    for (var field in fields) {
+      expecteds = fields[field];
+      actual = res.header[field.toLowerCase()];
+      if (null == actual) return fn(new Error('expected "' + field + '" header field'));
+      for (var i = 0; i < expecteds.length; i++) {
+        var fieldExpected = expecteds[i];
+        if (fieldExpected == actual) continue;
+        if (fieldExpected instanceof RegExp) re = fieldExpected;
+        if (re && re.test(actual)) continue;
+        if (re) return fn(new Error('expected "' + field + '" matching ' + fieldExpected + ', got "' + actual + '"'));
+        return fn(new Error('expected "' + field + '" of "' + fieldExpected + '", got "' + actual + '"'));
+      }
     }
-  }
 
-  // status
-  if (status) {
-    if (res.status !== status) {
+    // status
+    if (status && res.status !== status) {
       var a = http.STATUS_CODES[status];
       var b = http.STATUS_CODES[res.status];
       return fn(new Error('expected ' + status + ' "' + a + '", got ' + res.status + ' "' + b + '"'), res);
@@ -209,21 +236,21 @@ Test.prototype.assert = function(resError, res, fn){
     if (resError && resError instanceof Error && resError.status === status) {
       resError = null;
     }
-  }
 
-  // asserts
-  for (var i = 0; i < this._asserts.length; i++) {
-    var check = this._asserts[i];
-    var err;
-    try {
-      err = check(res);
-    } catch(e) {
-      err = e;
+
+    // asserts
+    for (var i = 0; i < this._asserts.length; i++) {
+      var check = this._asserts[i];
+      var err;
+      try {
+        err = check(res);
+      } catch(e) {
+        err = e;
+      }
+      if (!(err instanceof Error)) continue;
+      return fn(err instanceof Error ? err : new Error(err));
     }
-    if (!(err instanceof Error)) continue;
-    return fn(err instanceof Error ? err : new Error(err), res)
   }
-
   fn.call(this, resError, res);
 };
 

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -317,7 +317,7 @@ describe('request(app)', function(){
       });
     });
 
-    it('should assert the body before the status', function (done) {
+    it('should assert the status before the body', function (done) {
       var app = express();
 
       app.set('json spaces', 0);
@@ -331,7 +331,7 @@ describe('request(app)', function(){
       .expect(200)
       .expect('hey')
       .end(function(err, res){
-        err.message.should.equal('expected \'hey\' response body, got \'{"message":"something went wrong"}\'');
+          err.message.should.equal('expected 200 \"OK"\, got 500 \"Internal Server Error\"');
         done();
       });
     });
@@ -739,6 +739,66 @@ describe(".<http verb> works as expected", function(){
         .put('/')
         .expect(200, done);
     });
+});
+
+describe('assert ordering by call order', function() {
+  it('should assert the body before status', function(done) {
+    var app = express();
+
+    app.set('json spaces', 0);
+
+    app.get('/', function(req, res) {
+      res.send(500, {message: 'something went wrong'});
+    });
+
+    request(app)
+      .get('/')
+      .expect('hey')
+      .expect(200)
+      .end(function(err, res) {
+        err.message.should.equal('expected \'hey\' response body, got \'{"message":"something went wrong"}\'');
+        done();
+      });
+  });
+
+  it('should assert the status before body', function(done) {
+    var app = express();
+
+    app.set('json spaces', 0);
+
+    app.get('/', function(req, res) {
+      res.send(500, {message: 'something went wrong'});
+    });
+
+    request(app)
+      .get('/')
+      .expect(200)
+      .expect('hey')
+      .end(function(err, res) {
+        err.message.should.equal('expected 200 "OK", got 500 "Internal Server Error"');
+        done();
+      });
+  });
+
+
+  it('should assert the fields before body and status', function(done) {
+    var app = express();
+
+    app.set('json spaces', 0);
+
+    app.get('/', function(req, res) {
+      res.status(200).json({hello: 'world'});
+    });
+
+    request(app)
+      .get('/')
+      .expect('content-type', /html/)
+      .expect('hello')
+      .end(function(err, res) {
+        err.message.should.equal('expected "content-type" matching /html/, got "application/json; charset=utf-8"');
+        done();
+      });
+  });
 });
 
 describe("request.get(url).query(vals) works as expected", function(){


### PR DESCRIPTION
This should resolve issues like #173 and #197 by letting the user determine which error should bubble up first. 

Also added tests to validate ordering.