### PR TITLE
Check status first

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -151,6 +151,13 @@ Test.prototype.assert = function(resError, res, fn){
     , actual
     , re;
 
+  // status
+  if (status && res.status !== status) {
+    var a = http.STATUS_CODES[status];
+    var b = http.STATUS_CODES[res.status];
+    return fn(new Error('expected ' + status + ' "' + a + '", got ' + res.status + ' "' + b + '"'), res);
+  }
+
   // body
   for (var i = 0; i < bodies.length; i++) {
     var body = bodies[i];
@@ -195,13 +202,6 @@ Test.prototype.assert = function(resError, res, fn){
       if (re) return fn(new Error('expected "' + field + '" matching ' + fieldExpected + ', got "' + actual + '"'), res);
       return fn(new Error('expected "' + field + '" of "' + fieldExpected + '", got "' + actual + '"'), res);
     }
-  }
-
-  // status
-  if (status && res.status !== status) {
-    var a = http.STATUS_CODES[status];
-    var b = http.STATUS_CODES[res.status];
-    return fn(new Error('expected ' + status + ' "' + a + '", got ' + res.status + ' "' + b + '"'), res);
   }
 
   // asserts


### PR DESCRIPTION
It often happen that supertest complains that the body does not match, but the real cause is that there is an error (4XX or 5XX) and supertest should complain about this first. Then, if the status code matches, then it should check the body.