### PR TITLE
Support Windows contributors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,0 @@
-
-test:
-	@NODE_TLS_REJECT_UNAUTHORIZED=0 ./node_modules/.bin/mocha \
-		--require should \
-		--reporter spec \
-		--check-leaks
-
-.PHONY: test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "npm install",
-    "test": "make test"
+    "test": "mocha --require should --reporter spec --check-leaks"
   },
   "dependencies": {
     "superagent": "~1.2.0",

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -1,4 +1,6 @@
 
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var request = require('..')
   , https = require('https')
   , fs = require('fs')


### PR DESCRIPTION
Since we cannot invoke `Makefile`s easily and really, it can just be put in an `npm `script.