### PR TITLE
Suppress expected status code errors from superagent

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -60,20 +60,8 @@ describe('GET /users', function(){
 ```
 
 One thing to note with the above statement is that superagent now sends any HTTP
-error (anything other than a 2XX response code) to the callback as the first arguement. Example:
-
-```js
-describe('GET /redirect-url', function(){
-  it('respond with 302 redirect', function(done){
-    request(app)
-      .get('/redirect-url')
-      .expect(302, function (error) {
-        (error !== null).should.be.true;
-        done();
-      });
-  })
-})
-```
+error (anything other than a 2XX response code) to the callback as the first argument if
+you do not add a status code expect (i.e. `.expect(302)`).
 
   If you are using the `.end()` method `.expect()` assertions that fail will
   not throw - they will return the assertion as an error to the `.end()` callback. In

--- a/lib/test.js
+++ b/lib/test.js
@@ -198,10 +198,17 @@ Test.prototype.assert = function(resError, res, fn){
   }
 
   // status
-  if (status && res.status !== status) {
-    var a = http.STATUS_CODES[status];
-    var b = http.STATUS_CODES[res.status];
-    return fn(new Error('expected ' + status + ' "' + a + '", got ' + res.status + ' "' + b + '"'), res);
+  if (status) {
+    if (res.status !== status) {
+      var a = http.STATUS_CODES[status];
+      var b = http.STATUS_CODES[res.status];
+      return fn(new Error('expected ' + status + ' "' + a + '", got ' + res.status + ' "' + b + '"'), res);
+    }
+
+    // remove expected superagent error
+    if (resError && resError instanceof Error && resError.status === status) {
+      resError = null;
+    }
   }
 
   // asserts

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -155,7 +155,7 @@ describe('request(app)', function(){
 
     request(app)
     .get('/')
-    .expect(302, function() { done(); });
+    .expect(302, done);
   });
 
   it('should handle socket errors', function(done) {


### PR DESCRIPTION
This change will make it much, much easier to perform negative tests, while still leaving the superagent errors intact otherwise. Essentially what this intends to do is to suppress the superagent error if it's a status error for the error you were expecting to get.

fixes #221 

/cc @jonathanong @mikelax 