### PR TITLE
Run assertions in call order.

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -30,8 +30,6 @@ function Test(app, method, path) {
   this.redirects(0);
   this.buffer();
   this.app = app;
-  this._fields = [];
-  this._bodies = [];
   this._asserts = [];
   this.url = 'string' == typeof app
     ? app + path
@@ -88,20 +86,21 @@ Test.prototype.expect = function(a, b, c){
 
   // status
   if ('number' == typeof a) {
-    this._status = a;
+    this._asserts.push(this._assertStatus.bind(this, a));
     // body
-    if ('function' != typeof b && arguments.length > 1) this._bodies.push(b);
+    if ('function' != typeof b && arguments.length > 1)
+      this._asserts.push(this._assertBody.bind(this, b));
     return this;
   }
 
   // header field
   if ('string' == typeof b || 'number' == typeof b || b instanceof RegExp) {
-    this._fields.push({name: ''+a, value: b});
+    this._asserts.push(this._assertHeader.bind(this, {name: ''+a, value: b}));
     return this;
   }
 
   // body
-  this._bodies.push(a);
+  this._asserts.push(this._assertBody.bind(this, a));
 
   return this;
 };
@@ -144,27 +143,17 @@ Test.prototype.end = function(fn){
 Test.prototype.assert = function(resError, res, fn){
   var error;
 
-  // body
-  for (var i = 0; i < this._bodies.length && !error; i++) {
-    error = this._assertBody(this._bodies[i], res);
-  }
-
-  // fields
-  for (var i = 0; i < this._fields.length && !error; ++i) {
-    error = this._assertHeader(this._fields[i], res);
-  }
-
-  // status
-  if (!error) {
-    error = this._assertStatus(this._status, res, resError);
-  }
-
   // asserts
   for (var i = 0; i < this._asserts.length && !error; ++i) {
     error = this._assertFunction(this._asserts[i], res);
   }
 
-  fn.call(this, error, res);
+  // set unexpected superagent error if no other error has occurred.
+  if (!error && resError instanceof Error &&
+      (!res || resError.status !== res.status))
+    error = resError;
+
+  fn.call(this, error || null, res);
 };
 
 /**
@@ -232,24 +221,16 @@ Test.prototype._assertHeader = function(header, res) {
  *
  * @param {Number} status
  * @param {Response} res
- * @param {?Error} resError
  * @return {?Error}
  * @api private
  */
 
-Test.prototype._assertStatus = function(status, res, resError) {
-  if (!status)
-    return resError;
-
+Test.prototype._assertStatus = function(status, res) {
   if (res.status !== status) {
     var a = http.STATUS_CODES[status];
     var b = http.STATUS_CODES[res.status];
     return new Error('expected ' + status + ' "' + a + '", got ' + res.status + ' "' + b + '"');
   }
-
-  // return unexpected superagent error
-  if (resError instanceof Error && resError.status !== status)
-    return resError;
 };
 
 /**

--- a/lib/test.js
+++ b/lib/test.js
@@ -159,20 +159,13 @@ Test.prototype.assert = function(resError, res, fn){
   if (!error) {
     error = this._assertStatus(this._status, res, resError);
   }
-  if (error) return fn(error);
 
   // asserts
-  for (var i = 0; i < this._asserts.length; i++) {
-    var check = this._asserts[i];
-    var err;
-    try {
-      err = check(res);
-    } catch(e) {
-      err = e;
-    }
-    if (!(err instanceof Error)) continue;
-    return fn(err instanceof Error ? err : new Error(err), res)
+  for (var i = 0; i < this._asserts.length && !error; ++i) {
+    error = this._assertFunction(this._asserts[i], res);
   }
+
+  if (error) return fn(error);
 
   fn.call(this, error, res);
 };
@@ -260,6 +253,24 @@ Test.prototype._assertStatus = function(status, res, resError) {
   // return unexpected superagent error
   if (resError instanceof Error && resError.status !== status)
     return resError;
+};
+
+/**
+ * Performs an assertion by calling a function and return an Error upon failure.
+ *
+ * @param {Function} fn
+ * @param {Response} res
+ * @return {?Error}
+ * @api private
+ */
+Test.prototype._assertFunction = function(check, res) {
+  var err;
+  try {
+    err = check(res);
+  } catch(e) {
+    err = e;
+  }
+  if (err instanceof Error) return err;
 };
 
 /**

--- a/lib/test.js
+++ b/lib/test.js
@@ -135,8 +135,9 @@ Test.prototype.end = function(fn){
 };
 
 /**
- * Perform assertions and invoke `fn(err)`.
+ * Perform assertions and invoke `fn(err, res)`.
  *
+ * @param {?Error} resError
  * @param {Response} res
  * @param {Function} fn
  * @api private
@@ -164,8 +165,6 @@ Test.prototype.assert = function(resError, res, fn){
   for (var i = 0; i < this._asserts.length && !error; ++i) {
     error = this._assertFunction(this._asserts[i], res);
   }
-
-  if (error) return fn(error);
 
   fn.call(this, error, res);
 };

--- a/lib/test.js
+++ b/lib/test.js
@@ -146,41 +146,16 @@ Test.prototype.end = function(fn){
 Test.prototype.assert = function(resError, res, fn){
   var status = this._status
     , fields = this._fields
-    , bodies = this._bodies
+    , error
     , expecteds
     , actual
     , re;
 
   // body
-  for (var i = 0; i < bodies.length; i++) {
-    var body = bodies[i];
-    var isregexp = body instanceof RegExp;
-    // parsed
-    if ('object' == typeof body && !isregexp) {
-      try {
-        assert.deepEqual(body, res.body);
-      } catch (err) {
-        var a = util.inspect(body);
-        var b = util.inspect(res.body);
-        return fn(error('expected ' + a + ' response body, got ' + b, body, res.body), res);
-      }
-    } else {
-      // string
-      if (body !== res.text) {
-        var a = util.inspect(body);
-        var b = util.inspect(res.text);
-
-        // regexp
-        if (isregexp) {
-          if (!body.test(res.text)) {
-            return fn(error('expected body ' + b + ' to match ' + body, body, res.body), res);
-          }
-        } else {
-          return fn(error('expected ' + a + ' response body, got ' + b, body, res.body), res);
-        }
-      }
-    }
+  for (var i = 0; i < this._bodies.length && !error; i++) {
+    error = this._assertBody(this._bodies[i], res);
   }
+  if (error) return fn(error);
 
   // fields
   for (var field in fields) {
@@ -225,6 +200,44 @@ Test.prototype.assert = function(resError, res, fn){
   }
 
   fn.call(this, resError, res);
+};
+
+/**
+ * Perform assertions on a response body and return an Error upon failure.
+ *
+ * @param {Mixed} body
+ * @param {Response} res
+ * @return {?Error}
+ * @api private
+ */
+
+Test.prototype._assertBody = function(body, res) {
+  var isregexp = body instanceof RegExp;
+  // parsed
+  if ('object' == typeof body && !isregexp) {
+    try {
+      assert.deepEqual(body, res.body);
+    } catch (err) {
+      var a = util.inspect(body);
+      var b = util.inspect(res.body);
+      return error('expected ' + a + ' response body, got ' + b, body, res.body);
+    }
+  } else {
+    // string
+    if (body !== res.text) {
+      var a = util.inspect(body);
+      var b = util.inspect(res.text);
+
+      // regexp
+      if (isregexp) {
+        if (!body.test(res.text)) {
+          return error('expected body ' + b + ' to match ' + body, body, res.body);
+        }
+      } else {
+        return error('expected ' + a + ' response body, got ' + b, body, res.body);
+      }
+    }
+  }
 };
 
 /**

--- a/lib/test.js
+++ b/lib/test.js
@@ -78,8 +78,6 @@ Test.prototype.serverAddress = function(app, path){
  */
 
 Test.prototype.expect = function(a, b, c){
-  var self = this;
-
   // callback
   if ('function' == typeof a) {
     this._asserts.push(a);

--- a/lib/test.js
+++ b/lib/test.js
@@ -30,7 +30,7 @@ function Test(app, method, path) {
   this.redirects(0);
   this.buffer();
   this.app = app;
-  this._fields = {};
+  this._fields = [];
   this._bodies = [];
   this._asserts = [];
   this.url = 'string' == typeof app
@@ -98,8 +98,7 @@ Test.prototype.expect = function(a, b, c){
 
   // header field
   if ('string' == typeof b || 'number' == typeof b || b instanceof RegExp) {
-    if (!this._fields[a]) this._fields[a] = [];
-    this._fields[a].push(b);
+    this._fields.push({name: ''+a, value: b});
     return this;
   }
 
@@ -145,32 +144,18 @@ Test.prototype.end = function(fn){
 
 Test.prototype.assert = function(resError, res, fn){
   var status = this._status
-    , fields = this._fields
-    , error
-    , expecteds
-    , actual
-    , re;
+    , error;
 
   // body
   for (var i = 0; i < this._bodies.length && !error; i++) {
     error = this._assertBody(this._bodies[i], res);
   }
-  if (error) return fn(error);
 
   // fields
-  for (var field in fields) {
-    expecteds = fields[field];
-    actual = res.header[field.toLowerCase()];
-    if (null == actual) return fn(new Error('expected "' + field + '" header field'), res);
-    for (var i = 0; i < expecteds.length; i++) {
-      var fieldExpected = expecteds[i];
-      if (fieldExpected == actual) continue;
-      if (fieldExpected instanceof RegExp) re = fieldExpected;
-      if (re && re.test(actual)) continue;
-      if (re) return fn(new Error('expected "' + field + '" matching ' + fieldExpected + ', got "' + actual + '"'), res);
-      return fn(new Error('expected "' + field + '" of "' + fieldExpected + '", got "' + actual + '"'), res);
-    }
+  for (var i = 0; i < this._fields.length && !error; ++i) {
+    error = this._assertHeader(this._fields[i], res);
   }
+  if (error) return fn(error);
 
   // status
   if (status) {
@@ -237,6 +222,28 @@ Test.prototype._assertBody = function(body, res) {
         return error('expected ' + a + ' response body, got ' + b, body, res.body);
       }
     }
+  }
+};
+
+/**
+ * Perform assertions on a response header and return an Error upon failure.
+ *
+ * @param {Object} header
+ * @param {Response} res
+ * @return {?Error}
+ * @api private
+ */
+
+Test.prototype._assertHeader = function(header, res) {
+  var field = header.name;
+  var actual = res.header[field.toLowerCase()];
+  if (null == actual) return new Error('expected "' + field + '" header field');
+  var fieldExpected = header.value;
+  if (fieldExpected == actual) return;
+  if (fieldExpected instanceof RegExp) {
+    if (!fieldExpected.test(actual)) return new Error('expected "' + field + '" matching ' + fieldExpected + ', got "' + actual + '"');
+  } else {
+    return new Error('expected "' + field + '" of "' + fieldExpected + '", got "' + actual + '"');
   }
 };
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -143,8 +143,7 @@ Test.prototype.end = function(fn){
  */
 
 Test.prototype.assert = function(resError, res, fn){
-  var status = this._status
-    , error;
+  var error;
 
   // body
   for (var i = 0; i < this._bodies.length && !error; i++) {
@@ -155,21 +154,12 @@ Test.prototype.assert = function(resError, res, fn){
   for (var i = 0; i < this._fields.length && !error; ++i) {
     error = this._assertHeader(this._fields[i], res);
   }
-  if (error) return fn(error);
 
   // status
-  if (status) {
-    if (res.status !== status) {
-      var a = http.STATUS_CODES[status];
-      var b = http.STATUS_CODES[res.status];
-      return fn(new Error('expected ' + status + ' "' + a + '", got ' + res.status + ' "' + b + '"'), res);
-    }
-
-    // remove expected superagent error
-    if (resError && resError instanceof Error && resError.status === status) {
-      resError = null;
-    }
+  if (!error) {
+    error = this._assertStatus(this._status, res, resError);
   }
+  if (error) return fn(error);
 
   // asserts
   for (var i = 0; i < this._asserts.length; i++) {
@@ -184,7 +174,7 @@ Test.prototype.assert = function(resError, res, fn){
     return fn(err instanceof Error ? err : new Error(err), res)
   }
 
-  fn.call(this, resError, res);
+  fn.call(this, error, res);
 };
 
 /**
@@ -245,6 +235,31 @@ Test.prototype._assertHeader = function(header, res) {
   } else {
     return new Error('expected "' + field + '" of "' + fieldExpected + '", got "' + actual + '"');
   }
+};
+
+/**
+ * Perform assertions on the response status and return an Error upon failure.
+ *
+ * @param {Number} status
+ * @param {Response} res
+ * @param {?Error} resError
+ * @return {?Error}
+ * @api private
+ */
+
+Test.prototype._assertStatus = function(status, res, resError) {
+  if (!status)
+    return resError;
+
+  if (res.status !== status) {
+    var a = http.STATUS_CODES[status];
+    var b = http.STATUS_CODES[res.status];
+    return new Error('expected ' + status + ' "' + a + '", got ' + res.status + ' "' + b + '"');
+  }
+
+  // return unexpected superagent error
+  if (resError instanceof Error && resError.status !== status)
+    return resError;
 };
 
 /**

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -231,6 +231,44 @@ describe('request(app)', function(){
         });
       });
     });
+
+    it('should include the response in the error callback', function(done){
+      var app = express();
+
+      app.get('/', function(req, res){
+        res.send('whatever');
+      });
+
+      request(app)
+      .get('/')
+      .expect(function() {
+        throw new Error('Some error');
+      })
+      .end(function(err, res){
+        should.exist(err);
+        should.exist(res);
+        // Duck-typing response, just in case.
+        res.status.should.equal(200);
+        done();
+      });
+    });
+
+    it('should set `this` to the test object when calling the error callback', function(done) {
+      var app = express();
+
+      app.get('/', function(req, res){
+        res.send('whatever');
+      });
+
+      var test = request(app).get('/');
+      test.expect(function() {
+        throw new Error('Some error');
+      }).end(function(err, res){
+        should.exist(err);
+        this.should.eql(test);
+        done();
+      });
+    });
   });
 
   describe('.expect(status[, fn])', function(){

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -355,7 +355,7 @@ describe('request(app)', function(){
       });
     });
 
-    it('should assert the body before the status', function (done) {
+    it('should assert the status before the body', function (done) {
       var app = express();
 
       app.set('json spaces', 0);
@@ -369,7 +369,7 @@ describe('request(app)', function(){
       .expect(200)
       .expect('hey')
       .end(function(err, res){
-        err.message.should.equal('expected \'hey\' response body, got \'{"message":"something went wrong"}\'');
+          err.message.should.equal('expected 200 \"OK"\, got 500 \"Internal Server Error\"');
         done();
       });
     });
@@ -777,6 +777,66 @@ describe(".<http verb> works as expected", function(){
         .put('/')
         .expect(200, done);
     });
+});
+
+describe('assert ordering by call order', function() {
+  it('should assert the body before status', function(done) {
+    var app = express();
+
+    app.set('json spaces', 0);
+
+    app.get('/', function(req, res) {
+      res.send(500, {message: 'something went wrong'});
+    });
+
+    request(app)
+      .get('/')
+      .expect('hey')
+      .expect(200)
+      .end(function(err, res) {
+        err.message.should.equal('expected \'hey\' response body, got \'{"message":"something went wrong"}\'');
+        done();
+      });
+  });
+
+  it('should assert the status before body', function(done) {
+    var app = express();
+
+    app.set('json spaces', 0);
+
+    app.get('/', function(req, res) {
+      res.send(500, {message: 'something went wrong'});
+    });
+
+    request(app)
+      .get('/')
+      .expect(200)
+      .expect('hey')
+      .end(function(err, res) {
+        err.message.should.equal('expected 200 "OK", got 500 "Internal Server Error"');
+        done();
+      });
+  });
+
+
+  it('should assert the fields before body and status', function(done) {
+    var app = express();
+
+    app.set('json spaces', 0);
+
+    app.get('/', function(req, res) {
+      res.status(200).json({hello: 'world'});
+    });
+
+    request(app)
+      .get('/')
+      .expect('content-type', /html/)
+      .expect('hello')
+      .end(function(err, res) {
+        err.message.should.equal('expected "content-type" matching /html/, got "application/json; charset=utf-8"');
+        done();
+      });
+  });
 });
 
 describe("request.get(url).query(vals) works as expected", function(){


### PR DESCRIPTION
Tests should run in the order as specified by the developer. This allows us to modify the response to ease testing. Besides that, I noticed that the final callback was not always called with `this` set to `test`. This PR resolves these issues and fixes #173 and #197, and supersedes #197 and #200.

To ease reviewing, I implemented the feature in a few focused commits.

1. First 4 commits: Decompose the monolith `.assert` method. Most of this is just moving around some code, all tests still pass.
2. Commit 5: Restore the `res` parameter. I removed it in the first few commits, but there was no test that caught this, so I added a new test.
3. Commit 6: Cherry-picked tests from #200. These tests fail.
4. Commit 8: Add more tests, to verify all sane combinations of `.expect`, and in particular test the use case that I and #197 described. These tests also fail.
5. Commit 9: Implement the actual enforcement of test order. All tests pass!

I recommend to review the commits individually instead of the combined difference, because the first five commits accounts for most of the differences, but do not change the functionality. Thanks to the refactoring at this stage, the actual implementation of the new functionality is quite small and easy to review (commit 9).

Remark: Due to the implementation, the following test runs in `a, c, b, d` order. Let me know if you think that this should be changed to `a,b,c,d`, then I'll add another commit + test.

```
.expect(function a() { // push to _expectations stack
    this.expect(function b() {});
})
.expect(function c() {}) // push to _expectations stack
.end(function d() {}) // start tests and schedule final callback d.
// now a is called.
// b is pushed onto the _expectations stack.
// c is called.
// b is called.
// there are no more items in the _expectations stack, so d is called.
```