### PR TITLE
#237 Handle null res object when server is not responding.

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -199,10 +199,11 @@ Test.prototype.assert = function(resError, res, fn){
 
   // status
   if (status) {
-    if (res.status !== status) {
+    var resStatus = res ? res.status : 503;
+    if (resStatus !== status) {
       var a = http.STATUS_CODES[status];
-      var b = http.STATUS_CODES[res.status];
-      return fn(new Error('expected ' + status + ' "' + a + '", got ' + res.status + ' "' + b + '"'), res);
+      var b = http.STATUS_CODES[resStatus];
+      return fn(new Error('expected ' + status + ' "' + a + '", got ' + resStatus + ' "' + b + '"'), res);
     }
 
     // remove expected superagent error

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -23,6 +23,18 @@ describe('request(url)', function(){
     });
   });
 
+  it.skip('should fail if the server is off', function(done) {
+    request('http://localhost/foo')
+    .get('/')
+    .expect(503)
+    .end(function(err, res) {
+      if(err) {
+        return done(err);
+      }
+      done();
+    });
+  });
+
   describe('.end(cb)', function() {
     it('should set `this` to the test object when calling cb', function(done) {
       var app = express();


### PR DESCRIPTION
This PR address #237 for handling when server doesn't respond. 
I am using a 503 HTTP response code as that seems appropriate, but I am open to suggestions. 

The test case I added is skipped, because I can't get it to pass because of a connection error outside of supertest. 

```bash
  51 passing (276ms)
  1 failing

  1) request(url) should fail if the server is off:
     Error: connect ECONNREFUSED
      at exports._errnoException (util.js:746:11)
      at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1000:19)
```

I am not sure if there is a way to handle this use case as I believe the error is now outside of supertest / superagent. Any suggestions?
