### PR TITLE
Fixes #258, handles undefined Response object rather than throwing an…

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -199,15 +199,19 @@ Test.prototype.assert = function(resError, res, fn){
 
   // status
   if (status) {
+    if (resError && resError instanceof Error) {
+      // remove expected superagent error
+      if (resError.status === status) {
+        resError = null;
+      } else if (!res) {
+        return fn(resError);
+      }
+    }
+
     if (res.status !== status) {
       var a = http.STATUS_CODES[status];
       var b = http.STATUS_CODES[res.status];
       return fn(new Error('expected ' + status + ' "' + a + '", got ' + res.status + ' "' + b + '"'), res);
-    }
-
-    // remove expected superagent error
-    if (resError && resError instanceof Error && resError.status === status) {
-      resError = null;
     }
   }
 

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -252,6 +252,25 @@ describe('request(app)', function(){
         });
       });
     });
+
+    it('should handle error returned when server goes down', function (done) {
+      var app = express();
+
+      app.get('/', function(req, res){
+        res.end();
+      });
+
+      var s = app.listen(function(){
+        var url = 'http://localhost:' + s.address().port;
+        s.close();
+        request(url)
+        .get('/')
+        .expect(200, function (err) {
+          err.should.be.an.instanceof(Error);
+          return done();
+        });
+      });
+    });
   });
 
   describe('.expect(status[, fn])', function(){

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -231,6 +231,27 @@ describe('request(app)', function(){
         });
       });
     });
+
+    it('should handle an undefined Response', function (done) {
+      var app = express();
+
+      app.get('/', function(req, res){
+        setTimeout( function () {
+          res.end();
+        }, 20);
+      });
+
+      var s = app.listen(function(){
+        var url = 'http://localhost:' + s.address().port;
+        request(url)
+        .get('/')
+        .timeout(1)
+        .expect(200, function (err) {
+          err.should.be.an.instanceof(Error);
+          return done();
+        });
+      });
+    });
   });
 
   describe('.expect(status[, fn])', function(){


### PR DESCRIPTION
… uncaught error

I kept getting this error on random occasions:

```
/Users/Matt/open_source/express-route-validator/node_modules/supertest/lib/test.js:202
    if (res.status !== status) {
           ^
TypeError: Cannot read property 'status' of undefined
    at Test.assert (/Users/Matt/open_source/express-route-validator/node_modules/supertest/lib/test.js:202:12)
    at Server.assert (/Users/Matt/open_source/express-route-validator/node_modules/supertest/lib/test.js:131:12)
    at Server.g (events.js:180:16)
    at Server.emit (events.js:92:17)
    at net.js:1276:10
    at process._tickCallback (node.js:419:13)
```

When I dug down further, I could set that when `res` was `undefined`, it was because the server was unexpectedly timing out:

```
Error: connect ETIMEDOUT
    at errnoException (net.js:904:11)
    at Object.afterConnect [as oncomplete] (net.js:895:19)
```

So, if we check for the error first and fire the callback immediately there's not `res`, the problem is resolved.

This PR is an alternative to #240 and fixes #237 