### PR TITLE
Check that res is actually an object

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -198,7 +198,7 @@ Test.prototype.assert = function(resError, res, fn){
   }
 
   // status
-  if (status) {
+  if (status && res) {
     if (res.status !== status) {
       var a = http.STATUS_CODES[status];
       var b = http.STATUS_CODES[res.status];


### PR DESCRIPTION
In some situations, res does not have an object, for example, when setting a timeout and it actually times out.