### PR TITLE
Add example of using .expect() before an assertion.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -82,6 +82,28 @@ describe('GET /users', function(){
 });
 ```
 
+  Expectations are run in the order of definition. This characteristic can be used
+  to modify the response body or headers before executing an assertion.
+
+```js
+describe('GET /user', function(){
+  it('user.name should be an case-insensitive match for "tobi"', function(done){
+    request(app)
+      .get('/user')
+      .set('Accept', 'application/json')
+      .expect(function(res) {
+        res.body.id = 'some fixed id';
+        res.body.name = res.body.name.toUpperCase();
+      })
+      .expect(200, {
+        id: 'some fixed id',
+        name: 'TOBI'
+      }, done);
+  });
+});
+
+```
+
   Anything you can do with superagent, you can do with supertest - for example multipart file uploads!
 
 ```js


### PR DESCRIPTION
This documentation update is a follow-up to #239 (https://github.com/visionmedia/supertest/pull/239#issuecomment-133267946).