### PR TITLE
Handle superagent errors

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -31,6 +31,7 @@ function Test(app, method, path) {
   this.buffer();
   this.app = app;
   this._asserts = [];
+  this._assertedStatus = false;
   this.url = 'string' == typeof app
     ? app + path
     : this.serverAddress(app, path);
@@ -150,7 +151,7 @@ Test.prototype.assert = function(resError, res, fn){
 
   // set unexpected superagent error if no other error has occurred.
   if (!error && resError instanceof Error &&
-      (!res || resError.status !== res.status))
+    (!res || resError.status !== res.status || !this._assertedStatus))
     error = resError;
 
   fn.call(this, error || null, res);
@@ -226,6 +227,7 @@ Test.prototype._assertHeader = function(header, res) {
  */
 
 Test.prototype._assertStatus = function(status, res) {
+  this._assertedStatus = true;
   if (res.status !== status) {
     var a = http.STATUS_CODES[status];
     var b = http.STATUS_CODES[res.status];

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -198,6 +198,21 @@ describe('request(app)', function(){
     });
   });
 
+  it('should handle superagent errors', function(done) {
+    var app = express();
+
+    app.get('/', function(req, res){
+      res.sendStatus(400);
+    });
+
+    request(app)
+    .get('/')
+    .end(function(err) {
+      should.exist(err);
+      done();
+    });
+  });
+
   describe('.end(fn)', function(){
     it('should close server', function(done){
       var app = express();


### PR DESCRIPTION
The commit https://github.com/Rob--W/supertest/commit/5f238d2 by @Rob--W introduced a breaking change. The superagent errors are no longer handled and are discarded silently.
