### PR TITLE
set the execution context of 'expect' and 'end' to be the same

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -244,7 +244,7 @@ Test.prototype._assertStatus = function(status, res) {
 Test.prototype._assertFunction = function(check, res) {
   var err;
   try {
-    err = check(res);
+    err = check.call(this, res);
   } catch(e) {
     err = e;
   }

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -1029,3 +1029,26 @@ describe("request.get(url).query(vals) works as expected", function(){
     });
   });
 });
+
+
+describe('the execution context of expect and end', function() {
+  it('should be the same', function(done) {
+    var app = express();
+
+    app.get('/', function(req, res) {
+      res.end()
+    });
+
+    var executionContext
+
+    request(app)
+      .get('/')
+      .expect(function(){
+        executionContext = this
+      })
+      .end(function(err, res) {
+        executionContext.should.equal(this)
+        done();
+      });
+  });
+});


### PR DESCRIPTION
Right now the execution context of `end` and `expect` are different.  For example:

```
it("shows the value of this", function (done) {
  app.get('/api/v1/cohorts/ab')
    .expect(function () {
      console.log(this);
    })
    .end(function (err, response) {
      console.log(this);
      done()
    });
})
```

In `expect`, `this` is set to the global object / undefined, depending on the strict mode.  In `end`, it's set (usefully) to the test object.  

This pull request makes it so that in both cases the execution context is set to the Test object.

Tests included :)
