### PR TITLE
Add a .host() method to set a host other than 127.0.0.1

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -40,10 +40,16 @@ function TestAgent(app, options) {
 
 TestAgent.prototype.__proto__ = Agent.prototype;
 
+// set a host name
+TestAgent.prototype.host = function(host) {
+  this._host = host;
+  return this;
+};
+
 // override HTTP verb methods
 methods.forEach(function(method) {
   TestAgent.prototype[method] = function(url, fn) {   // eslint-disable-line no-unused-vars
-    var req = new Test(this.app, method.toUpperCase(), url);
+    var req = new Test(this.app, method.toUpperCase(), url, this._host);
     req.ca(this._ca);
     req.cert(this._cert);
     req.key(this._key);

--- a/lib/test.js
+++ b/lib/test.js
@@ -25,7 +25,7 @@ module.exports = Test;
  * @api public
  */
 
-function Test(app, method, path) {
+function Test(app, method, path, host) {
   Request.call(this, method.toUpperCase(), path);
   this.redirects(0);
   this.buffer();
@@ -33,7 +33,7 @@ function Test(app, method, path) {
   this._asserts = [];
   this.url = typeof app === 'string'
     ? app + path
-    : this.serverAddress(app, path);
+    : this.serverAddress(app, path, host);
 }
 
 /**
@@ -51,7 +51,7 @@ Test.prototype.__proto__ = Request.prototype;
  * @api private
  */
 
-Test.prototype.serverAddress = function(app, path) {
+Test.prototype.serverAddress = function(app, path, host) {
   var addr = app.address();
   var port;
   var protocol;
@@ -59,7 +59,7 @@ Test.prototype.serverAddress = function(app, path) {
   if (!addr) this._server = app.listen(0);
   port = app.address().port;
   protocol = app instanceof https.Server ? 'https' : 'http';
-  return protocol + '://127.0.0.1:' + port + path;
+  return protocol + '://' + (host || '127.0.0.1') + ':' + port + path;
 };
 
 /**

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -815,6 +815,25 @@ describe('request.agent(app)', function() {
   });
 });
 
+describe('agent.host(host)', function() {
+  it('should set request hostname', function(done) {
+    var app = express();
+    var agent = request.agent(app);
+
+    app.get('/', function(req, res) {
+      res.send();
+    });
+
+    agent
+    .host('something.test')
+    .get('/')
+    .end(function(err, res) {
+      err.hostname.should.equal('something.test');
+      done();
+    });
+  });
+});
+
 describe('.<http verb> works as expected', function() {
   it('.delete should work', function (done) {
     var app = express();


### PR DESCRIPTION
This allows you to set the server hostname before making a
request. If no hostname is set then it defaults to 127.0.0.1
