### PR TITLE
Output HTTP errors on unexpected status

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -227,6 +227,14 @@ Test.prototype._assertHeader = function(header, res) {
 
 Test.prototype._assertStatus = function(status, res) {
   if (res.status !== status) {
+
+    if (res.body && res.body.error) {
+      if (res.body.error.stack)
+        console.error('HTTP error stack:\n', res.body.error.stack);
+      else
+        console.error('HTTP error:\n', res.body.error);
+    }
+    
     var a = http.STATUS_CODES[status];
     var b = http.STATUS_CODES[res.status];
     return new Error('expected ' + status + ' "' + a + '", got ' + res.status + ' "' + b + '"');


### PR DESCRIPTION
This helps a lot during debug - let developer see not only that server returned wrong status, 
but also details, when available