### PR TITLE
Changed example with cookie-parser

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -134,12 +134,13 @@ request.get('/').expect('heya', function(err){
 ```js
 var request = require('supertest')
    , should = require('should')
-   , express = require('express');
+   , express = require('express')
+   , cookieParser = require('cookie-parser');
 
 
 describe('request.agent(app)', function(){
   var app = express();
-  app.use(express.cookieParser());
+  app.use(cookieParser());
 
   app.get('/', function(req, res){
     res.cookie('cookie', 'hey');


### PR DESCRIPTION
Cookie parser has been deleted from express and moved into https://github.com/expressjs/cookie-parser :)