### PR TITLE
Correct documentation for expect. Fixes #327, #236

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -194,7 +194,7 @@ describe('request.agent(app)', function(){
 
 ### .expect(function(res) {})
 
-  Pass a custom assertion function. It'll be given the response object to check. If the response is ok, it should return falsy, most commonly by not returning anything. If the check fails, throw an error or return a truthy value like a string that'll be turned into an error.
+  Pass a custom assertion function. It'll be given the response object to check. If the response is ok, it should return falsy, most commonly by not returning anything. If the check fails, throw an error.
 
   Here the string or error throwing options are both demonstrated:
 
@@ -205,7 +205,7 @@ describe('request.agent(app)', function(){
     .end(done);
 
   function hasPreviousAndNextKeys(res) {
-    if (!('next' in res.body)) return "missing next key";
+    if (!('next' in res.body)) throw new Error("missing next key");
     if (!('prev' in res.body)) throw new Error("missing prev key");
   }
   ```


### PR DESCRIPTION
Simply don't mention that a truthy value could be returned from expect