### PR TITLE
When listening on ipv6, use an ipv6 address.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "6"
   - "5"
   - "4"
   - "0.12"

--- a/lib/test.js
+++ b/lib/test.js
@@ -53,13 +53,16 @@ Test.prototype.__proto__ = Request.prototype;
 
 Test.prototype.serverAddress = function(app, path) {
   var addr = app.address();
-  var port;
+  var hostname;
   var protocol;
 
-  if (!addr) this._server = app.listen(0);
-  port = app.address().port;
+  if (!addr) {
+    this._server = app.listen(0);
+    addr = app.address();
+  }
+  hostname = addr.family === 'IPv6' ? '[::1]' : '127.0.01';
   protocol = app instanceof https.Server ? 'https' : 'http';
-  return protocol + '://127.0.0.1:' + port + path;
+  return protocol + '://' + hostname + ':' + addr.port + path;
 };
 
 /**


### PR DESCRIPTION
Otherwise, the client will connect to an ipv4 server if one is listening on the same port. This causes some strange and difficult to track down failures.
