### PR TITLE
Upgrade superagent to 2.x

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -42,10 +42,10 @@ methods.forEach(function(method) {
     var req = new Test(this.app, method.toUpperCase(), url);
     req.ca(this._ca);
 
-    req.on('response', this.saveCookies.bind(this));
-    req.on('redirect', this.saveCookies.bind(this));
-    req.on('redirect', this.attachCookies.bind(this, req));
-    this.attachCookies(req);
+    req.on('response', this._saveCookies.bind(this));
+    req.on('redirect', this._saveCookies.bind(this));
+    req.on('redirect', this._attachCookies.bind(this, req));
+    this._attachCookies(req);
 
     return req;
   };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "eslint lib/**/*.js test/**/*.js && mocha --require should --reporter spec --check-leaks"
   },
   "dependencies": {
-    "superagent": "^1.7.2",
+    "superagent": "^2.0.0",
     "methods": "1.x"
   },
   "devDependencies": {


### PR DESCRIPTION
@mikelax Updates superagent to 2.x with a minor change in code needed concerning binding of cookie functions now made private (prefixed `_`) in superagent. Alternative to my other pull request :shipit: 