### PR TITLE
Handle server not-running & superagent system errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.idea
+*.log

--- a/lib/test.js
+++ b/lib/test.js
@@ -146,25 +146,25 @@ Test.prototype.end = function(fn) {
 
 Test.prototype.assert = function(resError, res, fn) {
   var error;
+  var i;
 
   // check for unexpected network errors or server not running/reachable errors
   // when there is no response and superagent sends back a System Error
   // do not check further for other asserts, if any, in such case
   // https://nodejs.org/api/errors.html#errors_common_system_errors
-  var networkErrors = {
-    'ECONNREFUSED': 'Connection refused',
-    'ECONNRESET': 'Connection reset by peer',
-    'EPIPE': 'Broken pipe',
-    'ETIMEDOUT': 'Operation timed out'
+  var sysErrors = {
+    ECONNREFUSED: 'Connection refused',
+    ECONNRESET: 'Connection reset by peer',
+    EPIPE: 'Broken pipe',
+    ETIMEDOUT: 'Operation timed out'
   };
 
-  if (!res && resError && (resError instanceof Error) && (resError.syscall === 'connect') && (Object.getOwnPropertyNames(networkErrors).indexOf(resError.code) >= 0)) {
-    error = new Error(resError.code + ': ' + networkErrors[resError.code]);
+  if (!res && resError && (resError instanceof Error) && (resError.syscall === 'connect')
+      && (Object.getOwnPropertyNames(sysErrors).indexOf(resError.code) >= 0)) {
+    error = new Error(resError.code + ': ' + sysErrors[resError.code]);
     fn.call(this, error, null);
     return;
   }
-
-  var i;
 
   // asserts
   for (i = 0; i < this._asserts.length && !error; ++i) {

--- a/lib/test.js
+++ b/lib/test.js
@@ -146,6 +146,24 @@ Test.prototype.end = function(fn) {
 
 Test.prototype.assert = function(resError, res, fn) {
   var error;
+
+  // check for unexpected network errors or server not running/reachable errors
+  // when there is no response and superagent sends back a System Error
+  // do not check further for other asserts, if any, in such case
+  // https://nodejs.org/api/errors.html#errors_common_system_errors
+  var networkErrors = {
+    'ECONNREFUSED': 'Connection refused',
+    'ECONNRESET': 'Connection reset by peer',
+    'EPIPE': 'Broken pipe',
+    'ETIMEDOUT': 'Operation timed out'
+  };
+
+  if (!res && resError && (resError instanceof Error) && (resError.syscall === 'connect') && (Object.getOwnPropertyNames(networkErrors).indexOf(resError.code) >= 0)) {
+    error = new Error(resError.code + ': ' + networkErrors[resError.code]);
+    fn.call(this, error, null);
+    return;
+  }
+
   var i;
 
   // asserts

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -362,7 +362,7 @@ describe('request(app)', function() {
 
   describe('.expect(status)', function () {
     it('should handle connection error', function (done) {
-      var req = request.agent('http://localhost:1234')
+      var req = request.agent('http://localhost:1234');
 
       req
           .get('/')

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -361,6 +361,20 @@ describe('request(app)', function() {
   });
 
   describe('.expect(status)', function () {
+    it('should handle connection error', function (done) {
+      var req = request.agent('http://localhost:1234')
+
+      req
+          .get('/')
+          .expect(200)
+          .end(function (err, res) {
+            err.message.should.equal('ECONNREFUSED: Connection refused');
+            done();
+          });
+    });
+  });
+
+  describe('.expect(status)', function () {
     it('should assert only status', function (done) {
       var app = express();
 


### PR DESCRIPTION
If the server is not started then superagent sends back a ECONNREFUSED system error. Also because response is undefined in such case, running the sequence of asserts result in following error being thrown:

```
TypeError: Cannot read property 'status' of undefined
      at Test._assertStatus (lib/test.js:264:10)
      at Test._assertFunction (lib/test.js:282:11)
      at Test.assert (lib/test.js:170:18)
      at assert (lib/test.js:131:12)
      at lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:687:12)
      at ClientRequest.<anonymous> (node_modules/superagent/lib/node/index.js:639:10)
      at Socket.socketErrorListener (_http_client.js:306:9)
      at emitErrorNT (net.js:1272:8)
      at _combinedTickCallback (internal/process/next_tick.js:74:11)
      at process._tickCallback (internal/process/next_tick.js:98:9)
```

To reproduce this, run the following test:

```
describe(‘API Test’, function () {
    it('should handle return status 200’, function (done) {
      var req = request.agent('http://localhost:1234')

      req
          .get('/')
          .expect(200)
          .end(function (err, res) {
            done();
          });
    });
  });
```

This PR takes care of the above bug, and handles all System Errors returned by super agent gracefully. Running the above test now results in:

```
Error: ECONNREFUSED: Connection refused
      at Test.assert (lib/test.js:162:13)
      at assert (lib/test.js:131:12)
      at lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:687:12)
      at ClientRequest.<anonymous> (node_modules/superagent/lib/node/index.js:639:10)
      at Socket.socketErrorListener (_http_client.js:306:9)
      at emitErrorNT (net.js:1272:8)
      at _combinedTickCallback (internal/process/next_tick.js:74:11)
```
