### PR TITLE
Custom validators when comparing parsed bodies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.idea
+*.log

--- a/lib/test.js
+++ b/lib/test.js
@@ -6,7 +6,7 @@ var request = require('superagent');
 var util = require('util');
 var http = require('http');
 var https = require('https');
-var assert = require('assert');
+var deepEqual = require('./util').deepEqual;
 var Request = request.Request;
 
 /**
@@ -178,7 +178,7 @@ Test.prototype._assertBody = function(body, res) {
   // parsed
   if (typeof body === 'object' && !isregexp) {
     try {
-      assert.deepEqual(body, res.body);
+      deepEqual(res.body, body);
     } catch (err) {
       a = util.inspect(body);
       b = util.inspect(res.body);

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,99 @@
+var assert = require('assert');
+var util = require('util');
+
+exports.deepEqual = function deepEqual(actual, expected, message) {
+  if (!_deepEqual(actual, expected)) {
+    assert.fail(actual, expected, message, 'deepEqual', exports.deepEqual);
+  }
+};
+
+/**
+ * Version of {@link assert#deepEqual} that accepts functions in expected.
+ * @param actual
+ * @param expected
+ */
+function _deepEqual(actual, expected) {
+  var expectedKeys;
+  var actualKeys;
+  var expectedKey;
+  var actualKey;
+  var i;
+
+  // Custom validator.
+  if (typeof expected === 'function') {
+    return expected(actual);
+  }
+
+  // if (typeof expected.equals === 'function') { // not really reliable, we need an equals symbol :/
+  //   return expected.equals(actual);
+  // }
+
+  if (Object.is(actual, expected)) {
+    return true;
+  }
+
+  // They should have been equivalent.
+  if (util.isPrimitive(expected)) {
+    return false;
+  }
+
+  // Avoid checking `actual` is the same type each time.
+  if (Object.getPrototypeOf(expected) !== Object.getPrototypeOf(actual)) {
+    return false;
+  }
+
+  if (expected instanceof Date) {
+    return expected.getTime() === actual.getTime();
+  }
+
+  if (expected instanceof Buffer) {
+    return expected.equals(actual);
+  }
+
+  // 7.3 If the expected value is a RegExp object, the actual value is
+  // equivalent if it is also a RegExp object with the same source and
+  // properties (`global`, `multiline`, `lastIndex`, `ignoreCase`).
+  if (expected instanceof RegExp) {
+    return actual.source === expected.source &&
+      actual.global === expected.global &&
+      actual.multiline === expected.multiline &&
+      actual.lastIndex === expected.lastIndex &&
+      actual.ignoreCase === expected.ignoreCase;
+  }
+
+  // Other objects: Compare enumerable properties properties:
+  if (isArguments(expected)) {
+    // they have the same prototype as {}
+    if (!isArguments(actual)) {
+      return false;
+    }
+  }
+
+  expectedKeys = Object.keys(expected);
+  actualKeys = Object.keys(actual);
+  if (expectedKeys.length !== actualKeys.length) {
+    return false;
+  }
+
+  expectedKeys.sort();
+  actualKeys.sort();
+  for (i = expectedKeys.length - 1; i >= 0; i--) {
+    expectedKey = expectedKeys[i];
+    actualKey = actualKeys[i];
+
+    if (expectedKey !== actualKey) {
+      return false;
+    }
+
+    // compare property value
+    if (!_deepEqual(actual[actualKey], expected[expectedKey])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isArguments(object) {
+  return Object.prototype.toString.call(object) === '[object Arguments]';
+}

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -481,6 +481,36 @@ describe('request(app)', function() {
       });
     });
 
+    it('should allow functions when asserting the parsed response body', function(done) {
+      var app = express();
+
+      app.set('json spaces', 0);
+
+      app.get('/', function(req, res) {
+        res.send({ foo: (new Date()).toString() });
+      });
+
+      request(app)
+        .get('/')
+        .expect({
+          foo: function () {
+            return false;
+          }
+        })
+        .end(function(err, res) {
+          should.exist(err);
+
+          request(app)
+            .get('/')
+            .expect({
+              foo: function (val) {
+                return !Number.isNaN(Date.parse(val));
+              }
+            })
+            .end(done);
+        });
+    });
+
     it('should support regular expressions', function(done) {
       var app = express();
 


### PR DESCRIPTION
This pull request adds the possibility to define a function to call when validating one of the properties of a response. 

This enables developers to use `.expect(body)` even if they do not know what the server is going to send, without having to redefine the deep equal logic using .expect(function).

Usage example:
```
request(app)
  .post('/user')
  .send({
    username: 'ephys'
  }).expect({
    id: val => Number.isNumber(id),
    creationDate: val => !Number.isNaN(Date.parse(val)),
    username: 'ephys'
  })
```