### PR TITLE
fix request with content-length > 0 and content-encoding: gzip

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -26,7 +26,7 @@ module.exports = Test;
  */
 
 function Test(app, method, path) {
-  Request.call(this, method, path);
+  Request.call(this, method.toUpperCase(), path);
   this.redirects(0);
   this.buffer();
   this.app = app;

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -852,6 +852,26 @@ describe('.<http verb> works as expected', function() {
         .put('/')
         .expect(200, done);
   });
+  it('.head should work', function (done) {
+    var app = express();
+    app.head('/', function(req, res) {
+      res.statusCode = 200;
+      res.set('Content-Encoding', 'gzip');
+      res.set('Content-Length', '1024');
+      res.status(200);
+      res.end();
+    });
+
+    request(app)
+        .head('/')
+        .set('accept-encoding', 'gzip, deflate')
+        .end(function (err, res) {
+          if (err) return done(err);
+          res.should.have.property('statusCode', 200);
+          res.headers.should.have.property('content-length', '1024');
+          done();
+        });
+  });
 });
 
 describe('assert ordering by call order', function() {


### PR DESCRIPTION
The `Test` class wasn't constructing the `Request` instance with an uppercase method as it expects (e.g. [here](https://github.com/dynamicaction/superagent/blob/8d14c32dc3eacaaabc6457085ed8748075bc0ee7/lib/node/index.js#L417), [here](https://github.com/dynamicaction/superagent/blob/8d14c32dc3eacaaabc6457085ed8748075bc0ee7/lib/node/index.js#L136) and [here](https://github.com/dynamicaction/superagent/blob/8d14c32dc3eacaaabc6457085ed8748075bc0ee7/lib/node/index.js#L524)).

This results in a number of edge case bugs including on node 6 when a HEAD response has a `content-encoding` response of `gzip` and there is also a `content-length` > 0.  superagent would callback `Error: unexpected end of file`.  Superagent correctly interprets the [http spec](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13) by ignoring the content-length  and response body of a `HEAD` request.