### PR TITLE
Allow TestAgent pass a cert and key to request

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -25,9 +25,11 @@ module.exports = TestAgent;
 function TestAgent(app, options) {
   if (!(this instanceof TestAgent)) return new TestAgent(app, options);
   if (typeof app === 'function') app = http.createServer(app);  // eslint-disable-line no-param-reassign
-  if (options) this._ca = options.ca;
-  if (options) this._cert = options.cert;
-  if (options) this._key = options.key;
+  if (options) {
+    this._ca = options.ca;
+    this._key = options.key;
+    this._cert = options.cert;
+  }
   Agent.call(this);
   this.app = app;
 }

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -26,6 +26,8 @@ function TestAgent(app, options) {
   if (!(this instanceof TestAgent)) return new TestAgent(app, options);
   if (typeof app === 'function') app = http.createServer(app);  // eslint-disable-line no-param-reassign
   if (options) this._ca = options.ca;
+  if (options) this._cert = options.cert;
+  if (options) this._key = options.key;
   Agent.call(this);
   this.app = app;
 }
@@ -41,6 +43,8 @@ methods.forEach(function(method) {
   TestAgent.prototype[method] = function(url, fn) {   // eslint-disable-line no-unused-vars
     var req = new Test(this.app, method.toUpperCase(), url);
     req.ca(this._ca);
+    req.cert(this._cert);
+    req.key(this._key);
 
     req.on('response', this._saveCookies.bind(this));
     req.on('redirect', this._saveCookies.bind(this));


### PR DESCRIPTION
Superagent added the ability to set the SSL certificate and key parameters for requests, so they need to be added to supertest in order to pass them through to superagent.
