### PR TITLE
fix proposal for issue #317

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -31,6 +31,7 @@ function Test(app, method, path) {
   this.buffer();
   this.app = app;
   this._asserts = [];
+  this._callstacks = [] ;
   this.url = typeof app === 'string'
     ? app + path
     : this.serverAddress(app, path);
@@ -80,6 +81,7 @@ Test.prototype.serverAddress = function(app, path) {
 
 Test.prototype.expect = function(a, b, c) {
   // callback
+  this._callstacks.push(Error().stack.split('\n').splice(3));
   if (typeof a === 'function') {
     this._asserts.push(a);
     return this;
@@ -166,14 +168,20 @@ Test.prototype.assert = function(resError, res, fn) {
     return;
   }
 
+  var callstack ;
   // asserts
   for (i = 0; i < this._asserts.length && !error; i += 1) {
     error = this._assertFunction(this._asserts[i], res);
+    callstack=this._callstacks[i]
   }
 
   // set unexpected superagent error if no other error has occurred.
   if (!error && resError instanceof Error && (!res || resError.status !== res.status)) {
     error = resError;
+  }
+
+  if (error && callstack) {
+    error.stack=callstack.join("\n")
   }
 
   fn.call(this, error || null, res);


### PR DESCRIPTION
Added a buffer to store the callstack when the expect() function is called, then change the stack in the raised error when the assert fails.