### PR TITLE
Add post() examples to the README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -68,10 +68,11 @@ you do not add a status code expect (i.e. `.expect(302)`).
   order to fail the test case, you will need to rethrow or pass `err` to `done()`, as follows:
 
 ```js
-describe('GET /users', function() {
-  it('respond with json', function(done) {
+describe('POST /users', function() {
+  it('responds with json', function(done) {
     request(app)
-      .get('/users')
+      .post('/users')
+      .send({name: 'tobi'})
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
@@ -86,7 +87,7 @@ You can also use promises
 
 ```js
 describe('GET /users', function() {
-  it('respond with json', function() {
+  it('responds with json', function() {
     return request(app)
       .get('/users')
       .set('Accept', 'application/json')
@@ -102,10 +103,11 @@ describe('GET /users', function() {
   to modify the response body or headers before executing an assertion.
 
 ```js
-describe('GET /user', function() {
+describe('POST /user', function() {
   it('user.name should be an case-insensitive match for "tobi"', function(done) {
     request(app)
-      .get('/user')
+      .post('/user')
+      .send('name=tobi') // x-www-form-urlencoded upload
       .set('Accept', 'application/json')
       .expect(function(res) {
         res.body.id = 'some fixed id';


### PR DESCRIPTION
I have to look up how to do a POST request every time, for JSON and
x-www-form-urlencoded.

Many of the existing examples duplicate themselves, so I figured we
could change some of them to demonstrate the different ways to send a
POST request without changing the flow too much.