### PR TITLE
Fix #303 enhance #348 superagent error handling

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,7 +1,7 @@
 3.0.1 / 2017-19-17
 ===================
 
-  * PR-XXX - Harden TestAgent against errors in superagent and add a friendly error message. Takes care of confusion in #303 and #348.
+  * PR-440 - Harden TestAgent against errors in superagent and add a friendly error message. Takes care of confusion in #303 and #348.
 
 3.0.0 / 2017-01-29
 ===================

--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+3.0.1 / 2017-19-17
+===================
+
+  * PR-XXX - Harden TestAgent against errors in superagent and add a friendly error message. Takes care of confusion in #303 and #348.
+
 3.0.0 / 2017-01-29
 ===================
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -159,9 +159,18 @@ Test.prototype.assert = function(resError, res, fn) {
     ETIMEDOUT: 'Operation timed out'
   };
 
-  if (!res && resError && (resError instanceof Error) && (resError.syscall === 'connect')
-      && (Object.getOwnPropertyNames(sysErrors).indexOf(resError.code) >= 0)) {
-    error = new Error(resError.code + ': ' + sysErrors[resError.code]);
+  var isFromConnect = resError && resError.syscall === 'connect';
+  var isSysError = resError &&
+    Object.getOwnPropertyNames(sysErrors).indexOf(resError.code) >= 0;
+
+  if (!res && isSysError && isFromConnect) {
+    error = new Error(
+      'Error connecting to "' + this.url +
+      '": ' + sysErrors[resError.code] +
+      ' (' + resError.code + ').' +
+      '\nRequests to the same server must start with "/", for example "/api/test".' +
+      '\nSee https://visionmedia.github.io/superagent/#request-basics'
+    );
     fn.call(this, error, null);
     return;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supertest",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "SuperAgent driven library for testing HTTP servers",
   "main": "index.js",
   "scripts": {

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -368,7 +368,29 @@ describe('request(app)', function() {
           .get('/')
           .expect(200)
           .end(function (err, res) {
-            err.message.should.equal('ECONNREFUSED: Connection refused');
+            err.message.should.equal(
+              'Error connecting to "http://localhost:1234/": Connection refused (ECONNREFUSED).' +
+              '\nRequests to the same server must start with "/", for example "/api/test".' +
+              '\nSee https://visionmedia.github.io/superagent/#request-basics'
+            );
+            done();
+          });
+    });
+  });
+
+  describe('.expect(status)', function () {
+    it('should handle error from path not starting with "/"', function (done) {
+      var req = request.agent('http://localhost:1234');
+
+      req
+          .get('hello')
+          .expect(200)
+          .end(function (err, res) {
+            err.message.should.equal(
+              'Error connecting to "http://localhost:1234hello": Connection refused (ECONNREFUSED).' +
+              '\nRequests to the same server must start with "/", for example "/api/test".' +
+              '\nSee https://visionmedia.github.io/superagent/#request-basics'
+            );
             done();
           });
     });


### PR DESCRIPTION
- Fix logic introduced in #348 by removing assumption that superagent error is an instance of `Error` (actually `object`). This makes critical errors crash the test harness instead of reporting an error. The only solution is to read the code of the entire library and insert debug traces to isolate the source of the problem as network connection error.

- Friendly message for #303 necessary because users of supertest cannot be assumed to know anything about its dependency, superagent, and should be able to treat supertest as a black box with its own documentation. Supertest documentation does not mention anything about requiring request paths that start with `/`. This combined with the first problem will confuse new users and prevent them from using this library.

Additionally this should reduce or prevent confusion that caused the following issues to be filed:

- #237
- #248
- #258
- #370