### PR TITLE
Always pass on errors if no response

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -159,11 +159,13 @@ Test.prototype.assert = function(resError, res, fn) {
     ETIMEDOUT: 'Operation timed out'
   };
 
-  if (!res && resError && (resError instanceof Error) && (resError.syscall === 'connect')
-      && (Object.getOwnPropertyNames(sysErrors).indexOf(resError.code) >= 0)) {
-    error = new Error(resError.code + ': ' + sysErrors[resError.code]);
-    fn.call(this, error, null);
-    return;
+  if (!res && resError) {
+    if (resError instanceof Error && resError.syscall === 'connect'
+        && Object.getOwnPropertyNames(sysErrors).indexOf(resError.code) >= 0) {
+      error = new Error(resError.code + ': ' + sysErrors[resError.code]);
+    } else {
+      error = resError;
+    }
   }
 
   // asserts

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint-plugin-react": "6.4.1",
     "express": "~4.14.0",
     "mocha": "~3.2.0",
+    "nock": "^9.1.0",
     "should": "~11.2.0"
   },
   "engines": {


### PR DESCRIPTION
When an error occurs that prevents an http response from being generated, the exception is currently obscured by an error message like `Cannot read property 'status' of undefined`. This is because supertest is attempting to make assertions about the response, but the response is `undefined`. 

This updates the existing error logic, which handles network and system errors, to always return the error and skip response assertions if there is no response.

Fixes https://github.com/visionmedia/supertest/issues/352
Fixes https://github.com/visionmedia/supertest/issues/314
Fixes https://github.com/visionmedia/supertest/issues/370

cc @gr2m @wilhelmklopp