### PR TITLE
Support setting other defaults in the re-usable agent besides cookies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,16 @@ describe('request.agent(app)', function() {
     .expect('hey', done);
   });
 })
+
+Another use could be to automatically send an Authorization header by default:
+
+
+    var apiAgent = request.agent(app).set('Authorization', 'Bearer SOMETOKEN');
+
+    // Now run lots of tests against API that requires authetnication.
+    apiAgent.get(...)
+
+
 ```
   There is another example that is introduced by the file [agency.js](https://github.com/visionmedia/superagent/blob/master/test/node/agency.js)
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -58,6 +58,7 @@ methods.forEach(function(method) {
     req.on('redirect', this._saveCookies.bind(this));
     req.on('redirect', this._attachCookies.bind(this, req));
     this._attachCookies(req);
+    this._setDefaults(req);
 
     return req;
   };

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -847,6 +847,15 @@ describe('request.agent(app)', function () {
     else res.send(':(');
   });
 
+  // Echo back the authorization header we receive to test set() defaults
+  app.get('/set', function(req, res) {
+    if (req.get('authorization')) {
+      res.send(req.get('authorization'));
+    } else {
+      res.send(':(');
+    }
+  });
+
   it('should save cookies', function (done) {
     agent
       .get('/')
@@ -857,6 +866,15 @@ describe('request.agent(app)', function () {
     agent
       .get('/return')
       .expect('hey', done);
+  });
+
+
+  it('should support set() defaults', function(done) {
+    var defaultsAgent = request.agent(app).set('Authorization', 'Bearer');
+
+    defaultsAgent
+      .get('/set')
+      .expect('Bearer', done);
   });
 });
 


### PR DESCRIPTION
Since `superagent` 3.8, there has been support for the re-usable agent
supporting other defaults besides cookies.

For example, it's particularly useful to set default 'Authorization'
header before running repeated tests against an authenticated API.

I tracked down which version of `superagent` we needed to use as a
minimum dependency to this commit:

https://github.com/visionmedia/superagent/commit/66aed3427f29bf0c09b1df0e7f8aa9f0e30732ab

This update should be considered a bug fix, as 'supertest' claims to
support all of superagent's features, but this feature is documented in
superagent, but wasn't working in `supertest'.