### PR TITLE
Remove unused dependency in Readme.MD snippet

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -148,7 +148,6 @@ request.get('/').expect('heya', function(err){
 
 ```js
 const request = require('supertest');
-const should = require('should');
 const express = require('express');
 const cookieParser = require('cookie-parser');
 


### PR DESCRIPTION
Code snippet in Readme has a `require('should');` that's not used.