### PR TITLE
Fix example in README.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -111,7 +111,7 @@ describe('POST /user', function() {
       .set('Accept', 'application/json')
       .expect(function(res) {
         res.body.id = 'some fixed id';
-        res.body.name = res.body.name.toUpperCase();
+        res.body.name = res.body.name.toLowerCase();
       })
       .expect(200, {
         id: 'some fixed id',


### PR DESCRIPTION
From my point of view, there's a typo and it should be `name.toLowerCase()` instead of `name.toUpperCase()`.

```javascript
describe('POST /user', function() {
  it('user.name should be an case-insensitive match for "john"', function(done) {
    request(app)
      .post('/user')
      .send('name=john') // x-www-form-urlencoded upload
      .set('Accept', 'application/json')
      .expect(function(res) {
        res.body.id = 'some fixed id';
        res.body.name = res.body.name.toUpperCase();
      })
      .expect(200, {
        id: 'some fixed id',
        name: 'john'
      }, done);
  });
});
```