### PR TITLE
Use semver to declare superagent dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -484,9 +484,9 @@
       "dev": true
     },
     "cookiejar": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
-      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -979,9 +979,9 @@
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "external-editor": {
       "version": "2.2.0",
@@ -2076,14 +2076,14 @@
       "dev": true
     },
     "superagent": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.2.tgz",
-      "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
       "requires": {
         "component-emitter": "1.2.1",
-        "cookiejar": "2.1.1",
+        "cookiejar": "2.1.2",
         "debug": "3.1.0",
-        "extend": "3.0.1",
+        "extend": "3.0.2",
         "form-data": "2.3.2",
         "formidable": "1.2.1",
         "methods": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "methods": "~1.1.2",
-    "superagent": "3.8.2"
+    "superagent": "~3.8.3"
   },
   "devDependencies": {
     "body-parser": "^1.18.2",


### PR DESCRIPTION
We are currently experiencing some issues with superagent@3.8.2 which introduced a regression with persistent cookie over redirections. It was already solved in superagent@3.8.3 but since supertest is declaring a fixed dependency the issue still persist while using supertest.

I updated the dependency version and pattern to use tilde, since that is the pattern used for other dependencies.

https://github.com/visionmedia/superagent/releases/tag/v3.8.3