### PR TITLE
Use node 10 instead of node 9 (pipeline)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: node_js
 node_js:
   - 6
   - 8
-  - 9
+  - 10


### PR DESCRIPTION
Hello,

Travis pipeline: Use node 10 instead of node 9. 🚀

Regards, 