### PR TITLE
bugfix: 486 Change method to use deepStrictEqual.

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -198,7 +198,7 @@ Test.prototype._assertBody = function(body, res) {
   // parsed
   if (typeof body === 'object' && !isregexp) {
     try {
-      assert.deepEqual(body, res.body);
+      assert.deepStrictEqual(body, res.body);
     } catch (err) {
       a = util.inspect(body);
       b = util.inspect(res.body);

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -496,6 +496,37 @@ describe('request(app)', function() {
         });
     });
 
+    it('should test response object types', function (done) {
+      var app = express();
+      app.get('/', function (req, res) {
+        res.status(200).json({ stringValue: 'foo', numberValue: 3 });
+      });
+
+      request(app)
+        .get('/')
+        .expect({ stringValue: 'foo', numberValue: 3 }, done);
+    });
+
+    it('should deep test response object types', function (done) {
+      var app = express();
+      app.get('/', function (req, res) {
+        res.status(200)
+          .json({ stringValue: 'foo', numberValue: 3, nestedObject: { innerString: '5' } });
+      });
+
+      request(app)
+        .get('/')
+        .expect({ stringValue: 'foo', numberValue: 3, nestedObject: { innerString: 5 } })
+        .end(function(err, res) {
+          err.message.should.equal('expected { stringValue: \'foo\',\n  numberValue: 3,\n  nestedObject: { innerString: 5 } } response body, got { stringValue: \'foo\',\n  numberValue: 3,\n  nestedObject: { innerString: \'5\' } }'); // eslint-disable-line max-len
+
+          request(app)
+            .get('/')
+            .expect({ stringValue: 'foo', numberValue: 3, nestedObject: { innerString: '5' } })
+            .end(done);
+        });
+    });
+
     it('should support regular expressions', function(done) {
       var app = express();
 


### PR DESCRIPTION
Closes #486 

Change `_assertBody` to use `deepStrictEqual` instead of `deepEqual`