### PR TITLE
Use more robust Array type check

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -236,7 +236,7 @@ Test.prototype._assertHeader = function(header, res) {
 
   if (typeof actual === 'undefined') return new Error('expected "' + field + '" header field');
   // This check handles header values that may be a String or single element Array
-  if ((actual instanceof Array && actual.toString() === fieldExpected)
+  if ((Array.isArray(actual) && actual.toString() === fieldExpected)
     || fieldExpected === actual) {
     return;
   }


### PR DESCRIPTION
Improved robustness of Array type check by using `isArray` instead of instanceof. 

I have a project with supertest (^3.1.0) and Jest (^23.0.0) as test runner. For some reason, that I haven't yet been able to pinpoint, the array instance check fails for me.

Vars in scope:

```
actual = ["a"]
field = "set-cookie"
fieldExpected = "a"
```

when I evaluate the following expressions I get:

```
actual instanceof Array -> false
Array.isArray(actual) -> true
```

changing the check to use `isArray` makes it work for me. 

I suspect I'm running into some of the issues described over here: http://perfectionkills.com/instanceof-considered-harmful-or-how-to-write-a-robust-isarray/
