### PR TITLE
close koa servers when if tests finish

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -56,7 +56,7 @@ Test.prototype.serverAddress = function(app, path, host) {
   var port;
   var protocol;
 
-  if (!addr) this._server = app.listen(0);
+  if (!addr || addr.address === '::') this._server = app.listen(0);
   port = app.address().port;
   protocol = app instanceof https.Server ? 'https' : 'http';
   return protocol + '://' + (host || '127.0.0.1') + ':' + port + path;


### PR DESCRIPTION
This PR fixes the problem described at
https://github.com/visionmedia/supertest/issues/437
supertest did not shut down koa.js servers when tests finish running.