### PR TITLE
add code property to error

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -163,6 +163,7 @@ Test.prototype.assert = function(resError, res, fn) {
     if (resError instanceof Error && resError.syscall === 'connect'
         && Object.getOwnPropertyNames(sysErrors).indexOf(resError.code) >= 0) {
       error = new Error(resError.code + ': ' + sysErrors[resError.code]);
+      error.code = resError.code;
     } else {
       error = resError;
     }


### PR DESCRIPTION
I need some way to access the `code` property of an Error when it fits the criteria for [this](https://github.com/visionmedia/supertest/blob/master/lib/test.js#L163) `if` statement. Thanks!