### PR TITLE
Construct urls using `url.format()`

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -4,6 +4,7 @@
 
 var request = require('superagent');
 var util = require('util');
+var url = require('url');
 var http = require('http');
 var https = require('https');
 var assert = require('assert');
@@ -59,7 +60,13 @@ Test.prototype.serverAddress = function(app, path, host) {
   if (!addr) this._server = app.listen(0);
   port = app.address().port;
   protocol = app instanceof https.Server ? 'https' : 'http';
-  return protocol + '://' + (host || '127.0.0.1') + ':' + port + path;
+
+  return url.format({
+    protocol,
+    hostname: host || '127.0.0.1',
+    port,
+    pathname: path
+  });
 };
 
 /**

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -1,6 +1,7 @@
 const request = require('..');
 const https = require('https');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const should = require('should');
 const express = require('express');
@@ -876,18 +877,16 @@ describe('agent.host(host)', function () {
   it('should set request hostname', function (done) {
     const app = express();
     const agent = request.agent(app);
+    const localhostyName = os.hostname().toLowerCase();
 
     app.get('/', function (req, res) {
-      res.send();
+      res.send(req.hostname);
     });
 
     agent
-      .host('something.test')
+      .host(localhostyName)
       .get('/')
-      .end(function (err, res) {
-        err.hostname.should.equal('something.test');
-        done();
-      });
+      .expect(localhostyName, done);
   });
 });
 


### PR DESCRIPTION
This fixes strange errors when the requested path does not begin with a slash.

Also fix a test that wouldn't work by using `os.hostname()` to create a localhost-like name.