### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "methods": "^1.1.2",
-    "superagent": "^3.8.3"
+    "superagent": "^5.1.0"
   },
   "devDependencies": {
     "body-parser": "^1.18.3",


### PR DESCRIPTION
Seems to fix this warning for me:
> [DEP0010] DeprecationWarning: crypto.createCredentials is deprecated. Use tls.createSecureContext instead

`npm test` passed as well