### PR TITLE
Fix `end()` not called when app is started manually

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -58,7 +58,7 @@ Test.prototype.serverAddress = function(app, path, host) {
   var port;
   var protocol;
 
-  if (!addr) this._server = app.listen(0);
+  this._server = addr ? app : app.listen(0);
   port = app.address().port;
   protocol = app instanceof https.Server ? 'https' : 'http';
   return protocol + '://' + (host || '127.0.0.1') + ':' + port + path;

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -344,6 +344,24 @@ describe('request(app)', function () {
           });
       });
     });
+
+    it('should close server if the app was manually started', function (done) {
+      const app = express();
+      let test;
+
+      app.get('/', function (req, res) {
+        res.send('supertest FTW!');
+      });
+
+      test = request(app.listen())
+        .get('/')
+        .end(function () {
+        });
+
+      test._server.on('close', function () {
+        done();
+      });
+    });
   });
 
   describe('.expect(status[, fn])', function () {


### PR DESCRIPTION
Supertest supports passing previously-started apps, ie:

```js
const app = express();
const server = app.listen();

...

await request(server)
  .get('/user')
  .expect(200);
```

However, when used this way, the server was never called with `end()`.

Fixes #634