### PR TITLE
produces edited stack that starts with error name

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -80,7 +80,7 @@ function wrapAssertFn(assertFn) {
     var err = assertFn(res);
     if (err && err.stack) {
       badStack = err.stack.replace(err.message, '').split('\n').slice(1);
-      err.stack = [err.message, savedStack, '----', badStack].flat().join('\n');
+      err.stack = [err.toString(), savedStack, '----', badStack].flat().join('\n');
     }
     return err;
   };

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -12,6 +12,11 @@ const nock = require('nock');
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
+function shouldIncludeStackWithThisFile(err) {
+  err.stack.should.match(/test\/supertest.js:/);
+  err.stack.should.startWith(err.name + ':');
+}
+
 describe('request(url)', function () {
   it('should be supported', function (done) {
     const app = express();
@@ -359,7 +364,7 @@ describe('request(app)', function () {
         .expect(404)
         .end(function (err, res) {
           err.message.should.equal('expected 404 "Not Found", got 200 "OK"');
-          err.stack.should.match(/test\/supertest.js:/);
+          shouldIncludeStackWithThisFile(err);
           done();
         });
     });
@@ -420,7 +425,7 @@ describe('request(app)', function () {
           .expect(200, '')
           .end(function (err, res) {
             err.message.should.equal('expected \'\' response body, got \'foo\'');
-            err.stack.should.match(/test\/supertest.js:/);
+            shouldIncludeStackWithThisFile(err);
             done();
           });
       });
@@ -442,7 +447,7 @@ describe('request(app)', function () {
         .expect('hey')
         .end(function (err, res) {
           err.message.should.equal('expected \'hey\' response body, got \'{"foo":"bar"}\'');
-          err.stack.should.match(/test\/supertest.js:/);
+          shouldIncludeStackWithThisFile(err);
           done();
         });
     });
@@ -462,7 +467,7 @@ describe('request(app)', function () {
         .expect('hey')
         .end(function (err, res) {
           err.message.should.equal('expected 200 "OK", got 500 "Internal Server Error"');
-          err.stack.should.match(/test\/supertest.js:/);
+          shouldIncludeStackWithThisFile(err);
           done();
         });
     });
@@ -495,7 +500,7 @@ describe('request(app)', function () {
         .expect({ foo: 'baz' })
         .end(function (err, res) {
           err.message.should.equal('expected { foo: \'baz\' } response body, got { foo: \'bar\' }');
-          err.stack.should.match(/test\/supertest.js:/);
+          shouldIncludeStackWithThisFile(err);
 
           request(app)
             .get('/')
@@ -527,7 +532,7 @@ describe('request(app)', function () {
         .expect({ stringValue: 'foo', numberValue: 3, nestedObject: { innerString: 5 } })
         .end(function (err, res) {
           err.message.should.equal('expected {\n  stringValue: \'foo\',\n  numberValue: 3,\n  nestedObject: { innerString: 5 }\n} response body, got {\n  stringValue: \'foo\',\n  numberValue: 3,\n  nestedObject: { innerString: \'5\' }\n}'); // eslint-disable-line max-len
-          err.stack.should.match(/test\/supertest.js:/);
+          shouldIncludeStackWithThisFile(err);
 
           request(app)
             .get('/')
@@ -548,7 +553,7 @@ describe('request(app)', function () {
         .expect(/^bar/)
         .end(function (err, res) {
           err.message.should.equal('expected body \'foobar\' to match /^bar/');
-          err.stack.should.match(/test\/supertest.js:/);
+          shouldIncludeStackWithThisFile(err);
           done();
         });
     });
@@ -567,7 +572,7 @@ describe('request(app)', function () {
         .expect('hey tj')
         .end(function (err, res) {
           err.message.should.equal("expected 'hey' response body, got 'hey tj'");
-          err.stack.should.match(/test\/supertest.js:/);
+          shouldIncludeStackWithThisFile(err);
           done();
         });
     });
@@ -600,7 +605,7 @@ describe('request(app)', function () {
         .expect('Content-Foo', 'bar')
         .end(function (err, res) {
           err.message.should.equal('expected "Content-Foo" header field');
-          err.stack.should.match(/test\/supertest.js:/);
+          shouldIncludeStackWithThisFile(err);
           done();
         });
     });
@@ -618,7 +623,7 @@ describe('request(app)', function () {
         .end(function (err, res) {
           err.message.should.equal('expected "Content-Type" of "text/html", '
             + 'got "application/json; charset=utf-8"');
-          err.stack.should.match(/test\/supertest.js:/);
+          shouldIncludeStackWithThisFile(err);
           done();
         });
     });
@@ -650,7 +655,7 @@ describe('request(app)', function () {
         .end(function (err) {
           err.message.should.equal('expected "Content-Type" matching /^application/, '
             + 'got "text/html; charset=utf-8"');
-          err.stack.should.match(/test\/supertest.js:/);
+          shouldIncludeStackWithThisFile(err);
           done();
         });
     });
@@ -667,7 +672,7 @@ describe('request(app)', function () {
         .expect('Content-Length', 4)
         .end(function (err) {
           err.message.should.equal('expected "Content-Length" of "4", got "3"');
-          err.stack.should.match(/test\/supertest.js:/);
+          shouldIncludeStackWithThisFile(err);
           done();
         });
     });
@@ -694,7 +699,7 @@ describe('request(app)', function () {
           })
           .end(function (err) {
             err.message.should.equal('failed');
-            err.stack.should.match(/test\/supertest.js:/);
+            shouldIncludeStackWithThisFile(err);
             done();
           });
       });
@@ -720,7 +725,7 @@ describe('request(app)', function () {
           })
           .end(function (err) {
             err.message.should.equal('some descriptive error');
-            err.stack.should.match(/test\/supertest.js:/);
+            shouldIncludeStackWithThisFile(err);
             (err instanceof Error).should.be.true;
             done();
           });
@@ -761,7 +766,7 @@ describe('request(app)', function () {
           .expect('Content-Type', /json/)
           .end(function (err) {
             err.message.should.match(/Content-Type/);
-            err.stack.should.match(/test\/supertest.js:/);
+            shouldIncludeStackWithThisFile(err);
             done();
           });
       });
@@ -805,7 +810,7 @@ describe('request(app)', function () {
           .end(function (err) {
             err.message.should.equal('expected "Content-Type" matching /bloop/, '
               + 'got "text/html; charset=utf-8"');
-            err.stack.should.match(/test\/supertest.js:/);
+            shouldIncludeStackWithThisFile(err);
             done();
           });
       });
@@ -824,7 +829,7 @@ describe('request(app)', function () {
           .end(function (err) {
             err.message.should.equal('expected "Content-Type" matching /bloop/, '
               + 'got "text/html; charset=utf-8"');
-            err.stack.should.match(/test\/supertest.js:/);
+            shouldIncludeStackWithThisFile(err);
             done();
           });
       });
@@ -843,7 +848,7 @@ describe('request(app)', function () {
           .end(function (err) {
             err.message.should.equal('expected "Content-Type" matching /bloop/, '
               + 'got "text/html; charset=utf-8"');
-            err.stack.should.match(/test\/supertest.js:/);
+            shouldIncludeStackWithThisFile(err);
             done();
           });
       });
@@ -1002,7 +1007,7 @@ describe('assert ordering by call order', function () {
       .end(function (err, res) {
         err.message.should.equal('expected \'hey\' response body, '
           + 'got \'{"message":"something went wrong"}\'');
-        err.stack.should.match(/test\/supertest.js:/);
+        shouldIncludeStackWithThisFile(err);
         done();
       });
   });
@@ -1022,7 +1027,7 @@ describe('assert ordering by call order', function () {
       .expect('hey')
       .end(function (err, res) {
         err.message.should.equal('expected 200 "OK", got 500 "Internal Server Error"');
-        err.stack.should.match(/test\/supertest.js:/);
+        shouldIncludeStackWithThisFile(err);
         done();
       });
   });
@@ -1043,7 +1048,7 @@ describe('assert ordering by call order', function () {
       .end(function (err, res) {
         err.message.should.equal('expected "content-type" matching /html/, '
           + 'got "application/json; charset=utf-8"');
-        err.stack.should.match(/test\/supertest.js:/);
+        shouldIncludeStackWithThisFile(err);
         done();
       });
   });
@@ -1216,7 +1221,7 @@ describe('request.get(url).query(vals) works as expected', function () {
       .end(function (err, res) {
         err.should.be.an.instanceof(Error);
         err.message.should.match(/Nock: Disallowed net connect/);
-        err.stack.should.match(/test\/supertest.js:/);
+        shouldIncludeStackWithThisFile(err);
         done();
       });
 


### PR DESCRIPTION
I realized I introduced an issue in my previous PR (https://github.com/visionmedia/supertest/pull/690). This is the fix.

The result of the issue is that assertion messages would be output twice. Below is the output of a failed test on a private repo of mine using jest. Jest was able to point to the right place in the code where the failed `.expect` happened, but the assertion message was duplicated.

```
    expected 418 "I'm a Teapot", got 400 "Bad Request"expected 418 "I'm a Teapot", got 400 "Bad Request"

      580 |       });
      581 |       return sendRequest(token)
    > 582 |       .expect(418)
```

After some digging, I realized that the new stack being built started with `error.message`, and it should really start with `error.toString()`. See the real-life example below. The error stack starts with `Error: ` and then it continues with its `.message`.

```
> new Error('line two\nline one').stack
'Error: line two\n' +
  'line one\n' +
  '    at REPL48:1:1\n' +
…
```

I verified this code against tests running in another repo and displays assertion messages correctly. As far as I could test, only jest was impacted, but I would not be surprised that this impacts mocha and others, too.

Again, I'm so sorry about this. @niftylettuce, can you please review this and release a patch version? Thank you.