### PR TITLE
fix: Check error object before updating stack. (Fixes #700)

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -78,7 +78,7 @@ function wrapAssertFn(assertFn) {
   return function(res) {
     var badStack;
     var err = assertFn(res);
-    if (err && err.stack) {
+    if (err instanceof Error && err.stack) {
       badStack = err.stack.replace(err.message, '').split('\n').slice(1);
       err.stack = [err.toString()]
         .concat(savedStack)

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -738,6 +738,18 @@ describe('request(app)', function () {
           .end(done);
       });
 
+      it("doesn't create false negatives on non error objects", function (done) {
+        const handler = {
+          get: function(target, prop, receiver) {
+            throw Error('Should not be called for non Error objects');
+          }
+        };
+        const proxy = new Proxy({}, handler); // eslint-disable-line no-undef
+        get
+          .expect(() => proxy)
+          .end(done);
+      });
+
       it('handles multiple asserts', function (done) {
         const calls = [];
         get


### PR DESCRIPTION
Checking object returned by the assertion function in order to avoid property access errors when using assertion utilities like Chai, which would result in an error like this:

```
1) request(app)
       .expect(field, value[, fn])
         handling arbitrary expect functions
           doesn't create false negatives on assertion utilities:
     Error: Should not be called for non Error objects
      at Object.get (test/supertest.js:744:19)
      at ~/github/supertest/lib/test.js:29:367
      at Test._assertFunction (lib/test.js:99:170)
      at Test.assert (lib/test.js:66:173)
      at Server.localAssert (lib/test.js:54:664)
      at emitCloseNT (net.js:1657:8)
      at processTicksAndRejections (internal/process/task_queues.js:79:21)
```