### PR TITLE
Allows expect to accept an array of statuses

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -101,6 +101,7 @@ function wrapAssertFn(assertFn) {
  *   .expect('Content-Type', 'application/json')
  *   .expect('Content-Type', 'application/json', fn)
  *   .expect(fn)
+ *   .expect([200, 404])
  *
  * @return {Test}
  * @api public
@@ -122,6 +123,12 @@ Test.prototype.expect = function(a, b, c) {
     if (typeof b !== 'function' && arguments.length > 1) {
       this._asserts.push(wrapAssertFn(this._assertBody.bind(this, b)));
     }
+    return this;
+  }
+
+  // multiple statuses
+  if (Array.isArray(a)) {
+    this._asserts.push(wrapAssertFn(this._assertStatusArray.bind(this, a)));
     return this;
   }
 
@@ -294,6 +301,25 @@ Test.prototype._assertStatus = function(status, res) {
     a = http.STATUS_CODES[status];
     b = http.STATUS_CODES[res.status];
     return new Error('expected ' + status + ' "' + a + '", got ' + res.status + ' "' + b + '"');
+  }
+};
+
+/**
+ * Perform assertions on the response status and return an Error upon failure.
+ *
+ * @param {Array<Number>} statusArray
+ * @param {Response} res
+ * @return {?Error}
+ * @api private
+ */
+
+Test.prototype._assertStatusArray = function(statusArray, res) {
+  var b;
+  var expectedList;
+  if (!statusArray.includes(res.status)) {
+    b = http.STATUS_CODES[res.status];
+    expectedList = statusArray.join(', ');
+    return new Error('expected one of "' + expectedList + '", got ' + res.status + ' "' + b + '"');
   }
 };
 

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -399,6 +399,38 @@ describe('request(app)', function () {
     });
   });
 
+  describe('.expect(statusArray)', function () {
+    it('should assert only status', function (done) {
+      const app = express();
+
+      app.get('/', function (req, res) {
+        res.send('hey');
+      });
+
+      request(app)
+        .get('/')
+        .expect([200, 404])
+        .end(done);
+    });
+
+    it('should reject if status is not in valid statuses array', function (done) {
+      const app = express();
+
+      app.get('/', function (req, res) {
+        res.send('hey');
+      });
+
+      request(app)
+        .get('/')
+        .expect([500, 404])
+        .end(function (err, res) {
+          err.message.should.equal('expected one of "500, 404", got 200 "OK"');
+          shouldIncludeStackWithThisFile(err);
+          done();
+        });
+    });
+  });
+
   describe('.expect(status, body[, fn])', function () {
     it('should assert the response body and status', function (done) {
       const app = express();


### PR DESCRIPTION
By accepting an array of expected values for status, `expect` can now assert a set of returned statuses codes. This is useful when we don't know the exact code but we expect several codes that can all be valid responses: 200/204, redirects, etc. See: https://github.com/visionmedia/supertest/issues/389