### PR TITLE
Mitigate array-of-statuses' impact on JSON bodies

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -98,6 +98,7 @@ function wrapAssertFn(assertFn) {
  *   .expect(200, body)
  *   .expect('Some body')
  *   .expect('Some body', fn)
+ *   .expect(['json array body', { key: 'val' }])
  *   .expect('Content-Type', 'application/json')
  *   .expect('Content-Type', 'application/json', fn)
  *   .expect(fn)
@@ -127,7 +128,7 @@ Test.prototype.expect = function(a, b, c) {
   }
 
   // multiple statuses
-  if (Array.isArray(a)) {
+  if (Array.isArray(a) && a.every(val => typeof val === 'number')) {
     this._asserts.push(wrapAssertFn(this._assertStatusArray.bind(this, a)));
     return this;
   }

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -573,6 +573,17 @@ describe('request(app)', function () {
         });
     });
 
+    it('should support parsed response arrays', function (done) {
+      const app = express();
+      app.get('/', function (req, res) {
+        res.status(200).json(['a', { id: 1 }]);
+      });
+
+      request(app)
+        .get('/')
+        .expect(['a', { id: 1 }], done);
+    });
+
     it('should support regular expressions', function (done) {
       const app = express();
 


### PR DESCRIPTION
fixes a regression in #715 / v6.1.4 which introduces a breaking change where any array passed as the first argument to `.expect()` is treated as an array of status codes, rather than as a body which was the previous behaviour. This tries to minimise the impact of status code arrays.

Given, this will still break if the expected body is an array of numbers, but it will at least break less, and perhaps array bodies can be deprecated/removed in the next major release providing proper notice of the change?