### PR TITLE
Add on to the mitigation in https://github.com/visionmedia/supertest/…

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -128,7 +128,7 @@ Test.prototype.expect = function(a, b, c) {
   }
 
   // multiple statuses
-  if (Array.isArray(a) && a.every(val => typeof val === 'number')) {
+  if (Array.isArray(a) && a.length > 0 && a.every(val => typeof val === 'number')) {
     this._asserts.push(wrapAssertFn(this._assertStatusArray.bind(this, a)));
     return this;
   }

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -584,6 +584,17 @@ describe('request(app)', function () {
         .expect(['a', { id: 1 }], done);
     });
 
+    it('should support empty array responses', function (done) {
+      const app = express();
+      app.get('/', function (req, res) {
+        res.status(200).json([]);
+      });
+
+      request(app)
+        .get('/')
+        .expect([], done);
+    });
+
     it('should support regular expressions', function (done) {
       const app = express();
 


### PR DESCRIPTION
Add on to the mitigation in https://github.com/visionmedia/supertest/pull/728/commits.  
- As [].every(val => typeof val === 'number')) evaluates to true in legit cases where we expect the body to return empty array the tests will fail.
- Change is to also check for array length and defaulting to consider it as body instead of empty list of statues.