### PR TITLE
fix end function when piping on request

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -164,7 +164,9 @@ Test.prototype.end = function(fn) {
     localAssert();
 
     function localAssert() {
-      self.assert(err, res, fn);
+      if (fn) {
+        self.assert(err, res, fn);
+      }
     }
   });
 

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -4,6 +4,7 @@ const request = require('..');
 const https = require('https');
 const fs = require('fs');
 const path = require('path');
+const { Readable } = require('stream');
 const should = require('should');
 const express = require('express');
 const bodyParser = require('body-parser');
@@ -144,6 +145,28 @@ describe('request(app)', function () {
       .post('/')
       .send({ name: 'john' })
       .expect('john', done);
+  });
+
+  it('should work with pipe', function (done) {
+    const app = express();
+
+    app.use(express.json());
+
+    app.post('/', function (req, res) {
+      res.send(req.body.name);
+    });
+
+    const body = Readable.from(JSON.stringify({ name: 'john' }));
+    const req = request(app)
+      .post('/')
+      .set('Content-Type', 'application/json')
+      .on('response', function (res) {
+        should.exist(res);
+        res.status.should.be.equal(200);
+        res.text.should.be.equal('john');
+        done();
+      });
+    body.pipe(req);
   });
 
   it('should work when unbuffered', function (done) {


### PR DESCRIPTION
When I want to pipe to the request : 

```javascript
    const body = Readable.from(JSON.stringify({ name: 'john' }));
    const req = request(app)
      .post('/')
      .set('Content-Type', 'application/json')
      .on('response', function (res) {
        should.exist(res);
        res.status.should.be.equal(200);
        res.text.should.be.equal('john');
        done();
      });
    body.pipe(req);
```

I have an error ` Uncaught TypeError: Cannot read property 'call' of undefined`

This pull request have : 

- a unit test to reproduce the issue 
- the small fix that removes the call to `callback` function in the `end` function if it is empty.