### PR TITLE
Misc stuff

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,4 +43,4 @@ module.exports.Test = Test;
 /**
  * Expose the agent function
  */
-module.exports.agent = agent
+module.exports.agent = agent;

--- a/index.js
+++ b/index.js
@@ -3,9 +3,10 @@
 /**
  * Module dependencies.
  */
-var methods = require('methods');
-var Test = require('./lib/test');
-var http = require('http');
+const methods = require('methods');
+const http = require('http');
+const Test = require('./lib/test.js');
+const agent = require('./lib/agent.js');
 
 /**
  * Test against the given `app`,
@@ -42,4 +43,4 @@ module.exports.Test = Test;
 /**
  * Expose the agent function
  */
-module.exports.agent = require('./lib/agent');
+module.exports.agent = agent

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const agent = require('./lib/agent.js');
  * @api public
  */
 module.exports = function(app) {
-  var obj = {};
+  const obj = {};
 
   if (typeof app === 'function') {
     app = http.createServer(app); // eslint-disable-line no-param-reassign

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -7,7 +7,7 @@
 const { agent: Agent } = require('superagent');
 const methods = require('methods');
 const http = require('http');
-const Test = require('./test');
+const Test = require('./test.js');
 
 /**
  * Initialize a new `TestAgent`.

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -4,11 +4,6 @@
  * Module dependencies.
  */
 
-/**
- * Expose `Agent`.
- */
-
-module.exports = TestAgent;
 const { agent: Agent } = require('superagent');
 const methods = require('methods');
 const http = require('http');
@@ -68,3 +63,9 @@ methods.forEach(function(method) {
 });
 
 TestAgent.prototype.del = TestAgent.prototype.delete;
+
+/**
+ * Expose `Agent`.
+ */
+
+module.exports = TestAgent;

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -4,16 +4,15 @@
  * Module dependencies.
  */
 
-var Agent = require('superagent').agent;
-var methods = require('methods');
-var http = require('http');
-var Test = require('./test');
-
 /**
  * Expose `Agent`.
  */
 
 module.exports = TestAgent;
+const { agent: Agent } = require('superagent');
+const methods = require('methods');
+const http = require('http');
+const Test = require('./test');
 
 /**
  * Initialize a new `TestAgent`.
@@ -50,7 +49,7 @@ TestAgent.prototype.host = function(host) {
 // override HTTP verb methods
 methods.forEach(function(method) {
   TestAgent.prototype[method] = function(url, fn) { // eslint-disable-line no-unused-vars
-    var req = new Test(this.app, method.toUpperCase(), url, this._host);
+    const req = new Test(this.app, method.toUpperCase(), url, this._host);
     req.ca(this._ca);
     req.cert(this._cert);
     req.key(this._key);

--- a/lib/test.js
+++ b/lib/test.js
@@ -10,6 +10,8 @@ const { Server } = require('https');
 const { deepStrictEqual } = require('assert');
 const { Request } = require('superagent');
 
+/** @typedef {import('superagent').Response} Response */
+
 class Test extends Request {
   /**
    * Initialize a new `Test` with the given `app`,

--- a/lib/test.js
+++ b/lib/test.js
@@ -111,18 +111,16 @@ class Test extends Request {
    * @api public
    */
   end(fn) {
-    const self = this;
     const server = this._server;
-    const end = Request.prototype.end;
 
-    end.call(this, function (err, res) {
+    super.end((err, res) => {
+      const localAssert = () => {
+        this.assert(err, res, fn);
+      };
+
       if (server && server._handle) return server.close(localAssert);
 
       localAssert();
-
-      function localAssert() {
-        self.assert(err, res, fn);
-      }
     });
 
     return this;

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const request = require('..');
 const https = require('https');
 const fs = require('fs');
 const path = require('path');
@@ -9,6 +8,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const cookieParser = require('cookie-parser');
 const nock = require('nock');
+const request = require('../index.js');
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 


### PR DESCRIPTION
Small misc quality of dev fixes too small for one PR

not sure if you didn't want any of this small fixes. 
can easier be addressed if you just review and say what you didn't like about this PR so i can fix them.

- i moved a require() to the top
- and i used obj destructuring
- and explicit path with extension

all so it matches the similarity of how esm are built & required to be (for easier transition to esm if that day ever comes)
any chain use of `require('xyz').whatever...` only makes it harder to refactor to esm at some point later, and esm require explicit path so...

- used @typedef to import `superagent.Response` to not mix up with fetch response class...
- and removed the use of `self = this` with arrow fn

---

Also wanted to convert TestAgent into a class, but you allow it to be called without `new` so changing it would be a breaking change... (unless you do something like [this](https://stackoverflow.com/a/35339748/1008999))

also thought about using some [private class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields) but don't know how far you are willing to go with modernization 