### PR TITLE
[docs] add an example for complex object in multipart upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Anything you can do with superagent, you can do with supertest - for example mul
 request(app)
   .post('/')
   .field('name', 'my awesome avatar')
+  .field('complex_object', '{"attribute": "value"}', {contentType: 'application/json'})
   .attach('avatar', 'test/fixtures/avatar.jpg')
   ...
 ```


### PR DESCRIPTION
I have added an example in the README for adding a field in multipart upload with a JSON object.