### PR TITLE
fix: add stacktrace to failed expect function call

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -303,7 +303,12 @@ function wrapAssertFn(assertFn) {
 
   return function(res) {
     let badStack;
-    const err = assertFn(res);
+    let err;
+    try {
+      err = assertFn(res);
+    } catch (e) {
+      err = e;
+    }
     if (err instanceof Error && err.stack) {
       badStack = err.stack.replace(err.message, '').split('\n').slice(1);
       err.stack = [err.toString()]

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -9,6 +9,7 @@ const bodyParser = require('body-parser');
 const cookieParser = require('cookie-parser');
 const nock = require('nock');
 const request = require('../index.js');
+const throwError = require('./throwError');
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
@@ -748,9 +749,7 @@ describe('request(app)', function () {
 
       it('reports errors', function (done) {
         get
-          .expect(function (res) {
-            throw new Error('failed');
-          })
+          .expect(throwError('failed'))
           .end(function (err) {
             err.message.should.equal('failed');
             shouldIncludeStackWithThisFile(err);
@@ -774,9 +773,7 @@ describe('request(app)', function () {
 
       it('ensures truthy errors returned from asserts are throw to end', function (done) {
         get
-          .expect(function (res) {
-            return new Error('some descriptive error');
-          })
+          .expect(throwError('some descriptive error'))
           .end(function (err) {
             err.message.should.equal('some descriptive error');
             shouldIncludeStackWithThisFile(err);

--- a/test/throwError.js
+++ b/test/throwError.js
@@ -1,0 +1,10 @@
+'use strict';
+
+/**
+ * This method needs to reside in its own module in order to properly test stack trace handling.
+ */
+module.exports = function throwError(message) {
+  return function() {
+    throw new Error(message);
+  };
+};


### PR DESCRIPTION
Hi! First, thank you for maintaining this great tool 🙂

## Issue

When using a function call for the `expect` assertion, and throwing an error inside this function, the displayed stack trace does not contain the line of the test suite where the assertion is called. Instead, it will only contain the line where the exception is thrown.

This gets problematic when the assertion method is located in a module different from the test suite. In this case, the test suite is not even referenced. This can be verified in my first commit: https://github.com/visionmedia/supertest/commit/b24da855443221dd13c391aae9c4c40c7bd8fe7d

## Solution

The solution resides in my second commit: https://github.com/visionmedia/supertest/commit/3dba4e9df3f0f84fde1685c249aed3b1da636f05

As you can see, the `wrapAssertFn` is starting to look very similar to the `_assertFunction`. In my opinion, the `_assertFunction` could be removed altogether. However, I did not wander into this as this would probably be a breaking change. This method is part of the API, even if it is marked as internal. Please let me know what you think.