### PR TITLE
Update promise example to work with Mocha 3.0.0 and newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ You can also use promises:
 
 ```js
 describe('GET /users', function() {
-  it('responds with json', function(done) {
+  it('responds with json', function() {
     return request(app)
       .get('/users')
       .set('Accept', 'application/json')
@@ -119,9 +119,7 @@ describe('GET /users', function() {
       .expect(200)
       .then(response => {
           assert(response.body.email, 'foo@bar.com')
-          done();
       })
-      .catch(err => done(err))
   });
 });
 ```


### PR DESCRIPTION
This example fails with `Error: Resolution method is overspecified. Specify a callback *or* return a Promise; not both.` 

On mochajs.org: `In Mocha v3.0.0 and newer, returning a Promise and calling done() will result in an exception, as this is generally a mistake`