### PR TITLE
sync with superagent bug fixes

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -20,12 +20,7 @@ const Test = require('./test.js');
 function TestAgent(app, options) {
   if (!(this instanceof TestAgent)) return new TestAgent(app, options);
   if (typeof app === 'function') app = http.createServer(app); // eslint-disable-line no-param-reassign
-  if (options) {
-    this._ca = options.ca;
-    this._key = options.key;
-    this._cert = options.cert;
-  }
-  Agent.call(this);
+  Agent.call(this, options);
   this.app = app;
 }
 
@@ -45,9 +40,7 @@ TestAgent.prototype.host = function(host) {
 methods.forEach(function(method) {
   TestAgent.prototype[method] = function(url, fn) { // eslint-disable-line no-unused-vars
     const req = new Test(this.app, method.toUpperCase(), url, this._host);
-    req.ca(this._ca);
-    req.cert(this._cert);
-    req.key(this._key);
+
     if (this._host) {
       req.set('host', this._host);
     }

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -55,8 +55,8 @@ methods.forEach(function(method) {
     req.on('response', this._saveCookies.bind(this));
     req.on('redirect', this._saveCookies.bind(this));
     req.on('redirect', this._attachCookies.bind(this, req));
-    this._attachCookies(req);
     this._setDefaults(req);
+    this._attachCookies(req);
 
     return req;
   };

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -39,7 +39,7 @@ TestAgent.prototype.host = function(host) {
 // override HTTP verb methods
 methods.forEach(function(method) {
   TestAgent.prototype[method] = function(url, fn) { // eslint-disable-line no-unused-vars
-    const req = new Test(this.app, method.toUpperCase(), url, this._host);
+    const req = new Test(this.app, method.toUpperCase(), url);
 
     if (this._host) {
       req.set('host', this._host);


### PR DESCRIPTION
## fix
as `supertest` overrides some of the `superagent` implementations, it is important that fixes have to be ported over
- [fix(TestAgent): attach cookies to agent after plugin is used](https://github.com/visionmedia/supertest/commit/6d9b9cb9f362e54beb4bf2288b234d14f33b2e51)
  - following superagent: https://github.com/visionmedia/superagent/pull/1556

## feat
- [feat(TestAgent): decoupled `TestAgent` and superagent's `Agent`](https://github.com/visionmedia/supertest/commit/5e23869d1f936aa16c7e82e01a8684f6c54af910) 
    - `options` object is now a direct passthrough (no more hard-coding of `ca`, `key`, `cert`)

## refactor
- [refactor(TestAgent): removed the host param when creating `Test` object](https://github.com/visionmedia/supertest/commit/1c8930d2b1e904af8f5c6a567c232d45ef881bc1)
  - `Test` constructor has already removed the `host` param in https://github.com/visionmedia/supertest/commit/de056d2c904ae19f3bc3ac2b3015f88f06915bab