### PR TITLE
Refactor/test

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,40 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - node-version: 10.x
+            test-on-old-node: 1
+          - node-version: 12.x
+            test-on-old-node: 1
+          - node-version: 14.x
+          - node-version: 16.x
+          - node-version: 18.x
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - name: Install Dependencies On Old Node ${{ matrix.node-version }}
+      if: ${{ matrix.test-on-old-node == '1' }}
+      run: node ci/remove-deps-4-old-node.js && yarn install --ignore-scripts
+    - name: Install Dependencies On Node ${{ matrix.node-version }}
+      if: ${{ matrix.test-on-old-node != '1' }}
+      run: yarn install
+    - run: npm test
+    - name: Coverage On Node ${{ matrix.node-version }}
+      run:
+        npm run coverage

--- a/ci/remove-deps-4-old-node.js
+++ b/ci/remove-deps-4-old-node.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+const package = require('../package.json');
+
+const UNSUPPORT_DEPS_4_OLD = {
+  'eslint': undefined,
+  'mocha': '6.x'
+};
+
+const deps = Object.keys(UNSUPPORT_DEPS_4_OLD);
+for (const item in package.devDependencies) {
+  if (deps.includes(item)) {
+    package.devDependencies[item] = UNSUPPORT_DEPS_4_OLD[item];
+  }
+}
+
+delete package.scripts.lint;
+
+fs.writeFileSync(
+  path.join(__dirname, '../package.json'),
+  JSON.stringify(package, null, 2)
+);

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -20,12 +20,7 @@ const Test = require('./test.js');
 function TestAgent(app, options) {
   if (!(this instanceof TestAgent)) return new TestAgent(app, options);
   if (typeof app === 'function') app = http.createServer(app); // eslint-disable-line no-param-reassign
-  if (options) {
-    this._ca = options.ca;
-    this._key = options.key;
-    this._cert = options.cert;
-  }
-  Agent.call(this);
+  Agent.call(this, options);
   this.app = app;
 }
 
@@ -45,9 +40,7 @@ TestAgent.prototype.host = function(host) {
 methods.forEach(function(method) {
   TestAgent.prototype[method] = function(url, fn) { // eslint-disable-line no-unused-vars
     const req = new Test(this.app, method.toUpperCase(), url, this._host);
-    req.ca(this._ca);
-    req.cert(this._cert);
-    req.key(this._key);
+
     if (this._host) {
       req.set('host', this._host);
     }

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -55,8 +55,8 @@ methods.forEach(function(method) {
     req.on('response', this._saveCookies.bind(this));
     req.on('redirect', this._saveCookies.bind(this));
     req.on('redirect', this._attachCookies.bind(this, req));
-    this._attachCookies(req);
     this._setDefaults(req);
+    this._attachCookies(req);
 
     return req;
   };

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -39,7 +39,7 @@ TestAgent.prototype.host = function(host) {
 // override HTTP verb methods
 methods.forEach(function(method) {
   TestAgent.prototype[method] = function(url, fn) { // eslint-disable-line no-unused-vars
-    const req = new Test(this.app, method.toUpperCase(), url, this._host);
+    const req = new Test(this.app, method.toUpperCase(), url);
 
     if (this._host) {
       req.set('host', this._host);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "lint": "eslint lib/**/*.js test/**/*.js index.js",
     "lint:fix": "eslint --fix lib/**/*.js test/**/*.js index.js",
-    "pretest": "npm run lint",
+    "pretest": "npm run lint --if-present",
     "test": "nyc --reporter=html --reporter=text mocha --exit --require should --reporter spec --check-leaks",
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -80,7 +80,7 @@ describe('request(app)', function () {
       res.send('hey');
     });
 
-    server = app.listen(4000, function () {
+    server = app.listen(function () {
       request(server)
         .get('/')
         .end(function (err, res) {
@@ -99,8 +99,9 @@ describe('request(app)', function () {
       res.send('hey');
     });
 
-    server = app.listen(4001, function () {
-      request('http://localhost:4001')
+    server = app.listen(function () {
+      const url = 'http://localhost:' + server.address().port;
+      request(url)
         .get('/')
         .end(function (err, res) {
           res.status.should.equal(200);

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -20,14 +20,14 @@ function shouldIncludeStackWithThisFile(err) {
 describe('request(url)', function () {
   it('should be supported', function (done) {
     const app = express();
-    let s;
+    let server;
 
     app.get('/', function (req, res) {
       res.send('hello');
     });
 
-    s = app.listen(function () {
-      const url = 'http://localhost:' + s.address().port;
+    server = app.listen(function () {
+      const url = 'http://localhost:' + server.address().port;
       request(url)
         .get('/')
         .expect('hello', done);
@@ -37,14 +37,14 @@ describe('request(url)', function () {
   describe('.end(cb)', function () {
     it('should set `this` to the test object when calling cb', function (done) {
       const app = express();
-      let s;
+      let server;
 
       app.get('/', function (req, res) {
         res.send('hello');
       });
 
-      s = app.listen(function () {
-        const url = 'http://localhost:' + s.address().port;
+      server = app.listen(function () {
+        const url = 'http://localhost:' + server.address().port;
         const test = request(url).get('/');
         test.end(function (err, res) {
           this.should.eql(test);
@@ -93,12 +93,13 @@ describe('request(app)', function () {
 
   it('should work with remote server', function (done) {
     const app = express();
+    let server;
 
     app.get('/', function (req, res) {
       res.send('hey');
     });
 
-    app.listen(4001, function () {
+    server = app.listen(4001, function () {
       request('http://localhost:4001')
         .get('/')
         .end(function (err, res) {


### PR DESCRIPTION
- building on #791 

## test
- [test: 100% test coverage](https://github.com/visionmedia/supertest/commit/8bf4c1401d132a27633043810f859d23743ea1eb)
- [refactor(test): do not have both `s` and `server`, renamed to `server` for consistency](https://github.com/visionmedia/supertest/commit/c1c4402ab87019fc0d62ab2f094f419419598869) 
- [refactor(test): do not hardcode any ports, use ephemeral ports](https://github.com/visionmedia/supertest/commit/8847310ea86cebe415e92378eb8f3851d8e4057d)

## ci
- [ci: added ci](https://github.com/visionmedia/supertest/commit/da1e842171112e08f5044838cf3de4fac2ab7239)