### PR TITLE
ci: migrated code coverage from coveralls to codecov

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -38,3 +38,5 @@ jobs:
     - name: Coverage On Node ${{ matrix.node-version }}
       run:
         npm run coverage
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SuperTest
 
-[![Coveralls][coverage-badge]][coverage]
+[![code coverage][coverage-badge]][coverage]
 [![Build Status][travis-badge]][travis]
 [![Dependencies][dependencies-badge]][dependencies]
 [![PRs Welcome][prs-badge]][prs]
@@ -296,8 +296,8 @@ Inspired by [api-easy](https://github.com/flatiron/api-easy) minus vows coupling
 
 MIT
 
-[coverage-badge]: https://coveralls.io/repos/github/visionmedia/supertest/badge.svg?branch=master
-[coverage]: https://coveralls.io/github/visionmedia/supertest?branch=master
+[coverage-badge]: https://img.shields.io/codecov/c/github/visionmedia/supertest.svg
+[coverage]: https://codecov.io/gh/visionmedia/supertest
 [travis-badge]: https://travis-ci.org/visionmedia/supertest.svg?branch=master
 [travis]: https://travis-ci.org/visionmedia/supertest
 [dependencies-badge]: https://david-dm.org/visionmedia/supertest/status.svg

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint:fix": "eslint --fix lib/**/*.js test/**/*.js index.js",
     "pretest": "npm run lint --if-present",
     "test": "nyc --reporter=html --reporter=text mocha --exit --require should --reporter spec --check-leaks",
-    "coverage": "nyc report --reporter=text-lcov | coveralls"
+    "coverage": "nyc report --reporter=text-lcov > coverage.lcov"
   },
   "dependencies": {
     "methods": "^1.1.2",
@@ -38,7 +38,6 @@
   "devDependencies": {
     "body-parser": "^1.20.0",
     "cookie-parser": "^1.4.6",
-    "coveralls": "^3.1.1",
     "eslint": "^8.18.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.26.0",


### PR DESCRIPTION
Would need someone with write-access to activate https://codecov.io/gh/visionmedia/supertest before merging this PR.