### PR TITLE
docs: fixed links (for #621)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [SuperTest](https://visionmedia.github.io/superagent/)
+# [SuperTest](https://ladjs.github.io/superagent/)
 
 [![code coverage][coverage-badge]][coverage]
 [![Build Status][travis-badge]][travis]


### PR DESCRIPTION
Fixed the links for #621 due to migration from [visionmedia](https://github.com/visionmedia) to [ladjs](https://github.com/ladjs).
