### PR TITLE
Add cookie assertions framework

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 (The MIT License)
 
-Copyright (c) 2014 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2014 TJ Holowaychuk <tj@vision-media.ca> and other
+contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -319,6 +319,138 @@ function hasPreviousAndNextKeys(res) {
 
 Perform the request and invoke `fn(err, res)`.
 
+## Cookies
+
+Here is an example of using the `set` and `not` cookie assertions:
+
+```js
+// setup super-test
+const request = require('supertest');
+const express = require('express');
+const cookies = request.cookies;
+
+// setup express test service
+const app = express();
+
+app.get('/users', function(req, res) {
+  res.cookie('alpha', 'one', { domain: 'domain.com', path: '/', httpOnly: true });
+  res.send(200, { name: 'tobi' });
+});
+
+// test request to service
+request(app)
+  .get('/users')
+  .expect('Content-Type', /json/)
+  .expect('Content-Length', '15')
+  .expect(200)
+  // assert 'alpha' cookie is set with domain, path, and httpOnly options
+  .expect(cookies.set({ name: 'alpha', options: ['domain', 'path', 'httponly'] }))
+  // assert 'bravo' cookie is NOT set
+  .expect(cookies.not('set', { name: 'bravo' }))
+  .end(function(err, res) {
+    if (err) {
+      throw err;
+    }
+  });
+```
+
+It is also possible to chain assertions:
+
+```js
+cookies.set({/* ... */}).not('set', {/* ... */})
+```
+
+### Cookie assertions
+
+Functions and methods are chainable.
+
+#### cookies([secret], [asserts])
+
+Get assertion function for [super-test](https://github.com/visionmedia/supertest) `.expect()` method.
+
+*Arguments*
+
+- `secret` - String or array of strings. Cookie signature secrets.
+- `asserts(req, res)` - Function or array of functions. Failed custom assertions should throw.
+
+#### .set(expects, [assert])
+
+Assert that cookie and options are set.
+
+*Arguments*
+
+- `expects` - Object or array of objects.
+  - `name` - String name of cookie.
+  - `options` - *Optional* array of options.
+- `assert` - *Optional* boolean "assert true" modifier. Default: `true`.
+
+#### .reset(expects, [assert])
+
+Assert that cookie is set and was already set (in request headers).
+
+*Arguments*
+
+- `expects` - Object or array of objects.
+  - `name` - String name of cookie.
+- `assert` - *Optional* boolean "assert true" modifier. Default: `true`.
+
+#### .new(expects, [assert])
+
+Assert that cookie is set and was NOT already set (NOT in request headers).
+
+*Arguments*
+
+- `expects` - Object or array of objects.
+  - `name` - String name of cookie.
+- `assert` - *Optional* boolean "assert true" modifier. Default: `true`.
+
+#### .renew(expects, [assert])
+
+Assert that cookie is set with a strictly greater `expires` or `max-age` than the given value.
+
+*Arguments*
+
+- `expects` - Object or array of objects.
+  - `name` - String name of cookie.
+  - `options` - Object of options. `use one of two options below`
+  - `options`.`expires` - String UTC expiration for original cookie (in request headers).
+  - `options`.`max-age` - Integer ttl in seconds for original cookie (in request headers).
+- `assert` - *Optional* boolean "assert true" modifier. Default: `true`.
+
+#### .contain(expects, [assert])
+
+Assert that cookie is set with value and contains options.
+
+Requires `cookies(secret)` initialization if cookie is signed.
+
+*Arguments*
+
+- `expects` - Object or array of objects.
+  - `name` - String name of cookie.
+  - `value` - *Optional* string unsigned value of cookie.
+  - `options` - *Optional* object of options.
+  - `options`.`domain` - *Optional* string domain.
+  - `options`.`path` - *Optional* string path.
+  - `options`.`expires` - *Optional* string UTC expiration.
+  - `options`.`max-age` - *Optional* integer ttl, in seconds.
+  - `options`.`secure` - *Optional* boolean secure flag.
+  - `options`.`httponly` - *Optional* boolean httpOnly flag.
+- `assert` - *Optional* boolean "assert true" modifier. Default: `true`.
+
+#### .not(method, expects)
+
+Call any cookies assertion method with "assert true" modifier set to `false`.
+
+Syntactic sugar.
+
+*Arguments*
+
+- `method` - String method name. Arguments of method name apply in `expects`.
+- `expects` - Object or array of objects.
+  - `name` - String name of cookie.
+  - `value` - *Optional* string unsigned value of cookie.
+  - `options` - *Optional* object of options.
+
 ## Notes
 
 Inspired by [api-easy](https://github.com/flatiron/api-easy) minus vows coupling.

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ try {
 }
 const Test = require('./lib/test.js');
 const agent = require('./lib/agent.js');
+const cookies = require('./lib/cookies');
 
 /**
  * Test against the given `app`,
@@ -59,3 +60,8 @@ module.exports.Test = Test;
  * Expose the agent function
  */
 module.exports.agent = agent;
+
+/**
+ * Expose cookie assertions
+ */
+module.exports.cookies = cookies;

--- a/lib/cookies/assertion.js
+++ b/lib/cookies/assertion.js
@@ -1,0 +1,416 @@
+/** Copyright 2015 Gregory Langlais. See LICENSE.txt. */
+
+'use strict';
+
+const signature = require('cookie-signature');
+const should = require('should');
+
+/**
+ * Build Assertion function
+ *
+ * {object|object[]} expects cookies
+ * {string} expects.<name> and value of cookie
+ * {object} expects.options
+ * {string} [expects.options.domain]
+ * {string} [expects.options.path]
+ * {string} [expects.options.expires] UTC string using date.toUTCString()
+ * {number} [expects.options.max-age]
+ * {boolean} [expects.options.secure]
+ * {boolean} [expects.options.httponly]
+ * {string|string[]} [expects.secret]
+ *
+ * @param {null|string|string[]} [secret]
+ * @param {function|function[]} [asserts]
+ * @returns {Assertion}
+ */
+module.exports = function (secret, asserts) {
+  let assertions = [];
+
+  if (typeof secret === 'string') secret = [secret]; // eslint-disable-line no-param-reassign
+  else if (!Array.isArray(secret)) secret = []; // eslint-disable-line no-param-reassign
+
+  if (Array.isArray(asserts)) assertions = asserts;
+  else if (typeof asserts === 'function') assertions.push(asserts);
+
+  /**
+   * Assertion function with static chainable methods
+   *
+   * @param {object} res
+   * @returns {undefined|string}
+   * @constructor
+   */
+  function Assertion(res) {
+    if (typeof res !== 'object') throw new Error('res argument must be object');
+
+    // request and response object initialization
+    let request = {
+      headers: res.req.getHeaders(),
+      cookies: []
+    };
+
+    let response = {
+      headers: res.headers,
+      cookies: []
+    };
+
+    // build assertions request object
+    if (request.headers.cookie) {
+      const cookies = String(request.headers.cookie);
+      cookies.split(/; */).forEach(function (cookie) {
+        request.cookies.push(Assertion.parse(cookie));
+      });
+    }
+
+    // build assertions response object
+    if (
+      Array.isArray(response.headers['set-cookie'])
+      && response.headers['set-cookie'].length > 0
+    ) {
+      response.headers['set-cookie'].forEach(function (val) {
+        response.cookies.push(Assertion.parse(val));
+      });
+    }
+
+    // run assertions
+    let result;
+    assertions.every(function (assertion) {
+      result = assertion(request, response);
+      return (typeof (result) !== 'string');
+    });
+
+    return result;
+  }
+
+  /**
+   * Find cookie in stack/array
+   *
+   * @param {string} name
+   * @param {array} stack
+   * @returns {object|undefined} cookie
+   */
+  Assertion.find = function (name, stack) {
+    let cookie;
+
+    stack.every(function (val) {
+      if (name !== val.name) return true;
+      cookie = val;
+      return false;
+    });
+
+    return cookie;
+  };
+
+  /**
+   * Parse cookie string
+   *
+   * @param {string} str
+   * @param {object} [options]
+   * @param {function} [options.decode] uri
+   * @param {undefined|boolean} [options.request] headers
+   * @returns {object}
+   */
+  Assertion.parse = function (str, options) {
+    if (typeof str !== 'string') throw new TypeError('argument str must be a string');
+
+    if (typeof options !== 'object') options = {}; // eslint-disable-line no-param-reassign
+
+    let decode = options.decode || decodeURIComponent;
+
+    let parts = str.split(/; */);
+
+    let cookie = {};
+
+    parts.forEach(function (part, i) {
+      if (i === 1) cookie.options = {};
+
+      let equalsIndex = part.indexOf('=');
+
+      // things that don't look like key=value get true flag
+      if (equalsIndex < 0) {
+        cookie.options[part.trim().toLowerCase()] = true;
+        return;
+      }
+
+      const key = part.substr(0, equalsIndex).trim().toLowerCase();
+      // only assign once
+      if (typeof cookie[key] !== 'undefined') return;
+
+      equalsIndex += 1;
+      let val = part.substr(equalsIndex, part.length).trim();
+      // quoted values
+      if (val[0] === '"') val = val.slice(1, -1);
+
+      let value;
+      try {
+        value = decode(val);
+      } catch (e) {
+        value = val;
+      }
+
+      if (i > 0) {
+        cookie.options[key] = value;
+        return;
+      }
+
+      cookie.name = key;
+      cookie.value = decode(val);
+    });
+
+    if (typeof cookie.options === 'undefined') cookie.options = {};
+
+    return cookie;
+  };
+
+  /**
+   * Iterate expects
+   *
+   * @param {object|object[]} expects
+   * @param {boolean|function} hasValues
+   * @param {function} [cb]
+   */
+  Assertion.expects = function (expects, hasValues, cb) {
+    if (!Array.isArray(expects) && typeof expects === 'object') expects = [expects]; // eslint-disable-line no-param-reassign
+
+    let resolvedCb;
+    let resolvedHasValues;
+    if (typeof cb === 'undefined' && typeof hasValues === 'function') {
+      resolvedCb = hasValues;
+      resolvedHasValues = false;
+    } else {
+      resolvedCb = cb;
+      resolvedHasValues = hasValues;
+    }
+
+    expects.forEach(function (expect) {
+      let options = expect.options;
+      if (typeof options !== 'object' && !Array.isArray(options)) {
+        options = (resolvedHasValues) ? {} : [];
+      }
+
+      resolvedCb(Object.assign({}, expect, { options }));
+    });
+  };
+
+  /**
+   * Assert cookies and options are set
+   *
+   * @param {object|object[]} expects cookies
+   * @param {undefined|boolean} [assert]
+   * @returns {function} Assertion
+   */
+  Assertion.set = function (expects, assert) {
+    if (typeof assert === 'undefined') assert = true; // eslint-disable-line no-param-reassign
+
+    Assertion.expects(expects, function (expect) {
+      assertions.push(function (req, res) {
+        // get expectation cookie
+        const cookie = Assertion.find(expect.name, res.cookies);
+
+        if (assert && !cookie) throw new Error('expected: ' + expect.name + ' cookie to be set');
+
+        if (assert) should(cookie.options).have.properties(expect.options);
+        else if (cookie) should(cookie.options).not.have.properties(expect.options);
+      });
+    });
+
+    return Assertion;
+  };
+
+  /**
+   * Assert cookies has been reset
+   *
+   * @param {object|object[]} expects cookies
+   * @param {undefined|boolean} [assert]
+   * @returns {function} Assertion
+   */
+  Assertion.reset = function (expects, assert) {
+    if (typeof assert === 'undefined') assert = true; // eslint-disable-line no-param-reassign
+
+    Assertion.expects(expects, function (expect) {
+      assertions.push(function (req, res) {
+        // get sent cookie
+        const cookieReq = Assertion.find(expect.name, req.cookies);
+        // get expectation cookie
+        const cookieRes = Assertion.find(expect.name, res.cookies);
+
+        if (assert && (!cookieReq || !cookieRes)) {
+          throw new Error('expected: ' + expect.name + ' cookie to be set');
+        } else if (!assert && cookieReq && cookieRes) {
+          throw new Error('expected: ' + expect.name + ' cookie to be set');
+        }
+      });
+    });
+
+    return Assertion;
+  };
+
+  /**
+   * Assert cookies is set and new
+   *
+   * @param {object|object[]} expects cookies
+   * @param {undefined|boolean} [assert]
+   * @returns {function} Assertion
+   */
+  Assertion.new = function (expects, assert) {
+    if (typeof assert === 'undefined') assert = true; // eslint-disable-line no-param-reassign
+
+    Assertion.expects(expects, function (expect) {
+      assertions.push(function (req, res) {
+        // get sent cookie
+        const cookieReq = Assertion.find(expect.name, req.cookies);
+        // get expectation cookie
+        const cookieRes = Assertion.find(expect.name, res.cookies);
+
+        if (assert) {
+          if (!cookieRes) throw new Error('expected: ' + expect.name + ' cookie to be set');
+          if (cookieReq && cookieRes) {
+            throw new Error('expected: ' + expect.name + ' cookie to NOT already be set');
+          }
+        } else if (!cookieReq || !cookieRes) {
+          throw new Error('expected: ' + expect.name + ' cookie to be set');
+        }
+      });
+    });
+
+    return Assertion;
+  };
+
+  /**
+   * Assert cookies expires or max-age has increased
+   *
+   * @param {object|object[]} expects cookies
+   * @param {undefined|boolean} [assert]
+   * @returns {function} Assertion
+   */
+  Assertion.renew = function (expects, assert) {
+    if (typeof assert === 'undefined') assert = true; // eslint-disable-line no-param-reassign
+
+    Assertion.expects(expects, true, function (expect) {
+      const expectExpires = new Date(expect.options.expires);
+      const expectMaxAge = parseFloat(expect.options['max-age']);
+
+      let baseMessage = 'expected: ' + expect.name;
+      if (!expectExpires.getTime() && !expectMaxAge) {
+        throw new Error(baseMessage + ' expects to have expires or max-age option');
+      }
+
+      assertions.push(function (req, res) {
+        // get sent cookie
+        const cookieReq = Assertion.find(expect.name, req.cookies);
+        // get expectation cookie
+        const cookieRes = Assertion.find(expect.name, res.cookies);
+
+        const cookieMaxAge = (expectMaxAge && cookieRes)
+          ? parseFloat(cookieRes.options['max-age'])
+          : undefined;
+        const cookieExpires = (expectExpires.getTime() && cookieRes)
+          ? new Date(cookieRes.options.expires)
+          : undefined;
+
+        if (assert) {
+          if (!cookieReq || !cookieRes) {
+            throw new Error(baseMessage + ' cookie to be set');
+          }
+          if (expectMaxAge && (!cookieMaxAge || cookieMaxAge <= expectMaxAge)) {
+            throw new Error(baseMessage + ' cookie max-age to be greater than existing value');
+          }
+
+          if (
+            expectExpires.getTime()
+            && (!cookieExpires.getTime() || cookieExpires <= expectExpires)
+          ) {
+            throw new Error(baseMessage + ' cookie expires to be greater than existing value');
+          }
+        } else if (cookieRes) {
+          if (expectMaxAge && cookieMaxAge > expectMaxAge) {
+            throw new Error(
+              baseMessage + ' cookie max-age to be less than or equal to existing value'
+            );
+          }
+
+          if (expectExpires.getTime() && cookieExpires > expectExpires) {
+            throw new Error(
+              baseMessage + ' cookie expires to be less than or equal to existing value'
+            );
+          }
+        }
+      });
+    });
+
+    return Assertion;
+  };
+
+  /**
+   * Assert cookies contains values
+   *
+   * @param {object|object[]} expects cookies
+   * @param {undefined|boolean} [assert]
+   * @returns {function} Assertion
+   */
+  Assertion.contain = function (expects, assert) {
+    if (typeof assert === 'undefined') assert = true; // eslint-disable-line no-param-reassign
+
+    Assertion.expects(expects, function (expect) {
+      const keys = Object.keys(expect.options);
+
+      assertions.push(function (req, res) {
+        // get expectation cookie
+        const cookie = Assertion.find(expect.name, res.cookies);
+
+        if (!cookie) throw new Error('expected: ' + expect.name + ' cookie to be set');
+
+        // check cookie values are equal
+        if ('value' in expect) {
+          try {
+            if (assert) should(cookie.value).be.eql(expect.value);
+            else should(cookie.value).not.be.eql(expect.value);
+          } catch (e) {
+            if (secret.length) {
+              let value;
+              secret.every(function (sec) {
+                value = signature.unsign(cookie.value.slice(2), sec);
+                return !(value && value === expect.value);
+              });
+
+              if (assert && !value) {
+                throw new Error('expected: ' + expect.name + ' value to equal ' + expect.value);
+              } else if (!assert && value) {
+                throw new Error('expected: ' + expect.name + ' value to NOT equal ' + expect.value);
+              }
+            } else throw e;
+          }
+        }
+
+        keys.forEach(function (key) {
+          const expected = (
+            key === 'max-age'
+              ? expect.options[key].toString()
+              : expect.options[key]
+          );
+          if (assert) should(cookie.options[key]).be.eql(expected);
+          else should(cookie.options[key]).not.be.eql(expected);
+        });
+      });
+    });
+
+    return Assertion;
+  };
+
+  /**
+   * Assert NOT modifier
+   *
+   * @param {function} method
+   * @param {...*}
+   */
+  Assertion.not = function (method) {
+    let args = [];
+
+    for (let i = 1; i < arguments.length; i += 1) args.push(arguments[i]);
+
+    args.push(false);
+
+    return Assertion[method].apply(Assertion, args);
+  };
+
+  return Assertion;
+};

--- a/lib/cookies/index.js
+++ b/lib/cookies/index.js
@@ -1,0 +1,32 @@
+/** Copyright 2015 Gregory Langlais. See LICENSE.txt. */
+
+'use strict';
+
+const Assertion = require('./Assertion');
+
+/**
+ * Construct cookies assertion (function)
+ *
+ * @param {null|string|string[]} [secret]
+ * @param {function(req, res)[]} [asserts] ran within returned assertion function
+ * @returns {function} assertion
+ * @constructor
+ */
+function ExpectCookies(secret, asserts) {
+  return Assertion(secret, asserts);
+}
+
+// build ExpectCookies proxy methods
+const assertion = Assertion();
+const methods = Object.getOwnPropertyNames(assertion);
+
+methods.forEach(function(method) {
+  if (typeof assertion[method] === 'function' && typeof Function[method] === 'undefined') {
+    ExpectCookies[method] = function() {
+      const newAssertion = Assertion();
+      return newAssertion[method].apply(newAssertion, arguments);
+    };
+  }
+});
+
+module.exports = ExpectCookies;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "7.1.4",
       "license": "MIT",
       "dependencies": {
+        "cookie-signature": "^1.2.2",
         "methods": "^1.1.2",
         "superagent": "^10.2.3"
       },
@@ -25,7 +26,8 @@
         "nock": "^13.3.8",
         "nyc": "^15.1.0",
         "proxyquire": "^2.1.3",
-        "should": "^13.2.3"
+        "should": "^13.2.3",
+        "sinon": "20.0.0"
       },
       "engines": {
         "node": ">=14.18.0"
@@ -899,6 +901,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.3.tgz",
+      "integrity": "sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "dev": true,
@@ -1661,10 +1704,21 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/cookie-signature": {
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/cookiejar": {
       "version": "2.1.4",
@@ -2550,6 +2604,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/express/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5878,6 +5939,34 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sinon": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-20.0.0.tgz",
+      "integrity": "sha512-+FXOAbdnj94AQIxH0w1v8gzNxkawVvNqE3jUzRLptR71Oykeu2RrQXXl/VQjKay+Qnh73fDt/oDfMo6xMeDQbQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.5",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "dev": true,
@@ -6330,6 +6419,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "contributors": [],
   "dependencies": {
     "methods": "^1.1.2",
-    "superagent": "^10.2.3"
+    "superagent": "^10.2.3",
+    "cookie-signature": "^1.2.2"
   },
   "devDependencies": {
     "@commitlint/cli": "17",
@@ -21,7 +22,8 @@
     "nock": "^13.3.8",
     "nyc": "^15.1.0",
     "proxyquire": "^2.1.3",
-    "should": "^13.2.3"
+    "should": "^13.2.3",
+    "sinon": "20.0.0"
   },
   "engines": {
     "node": ">=14.18.0"

--- a/test/cookies.js
+++ b/test/cookies.js
@@ -1,0 +1,1284 @@
+/** Copyright 2015 Gregory Langlais. See LICENSE.txt. */
+
+'use strict';
+
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const request = require('../index');
+const should = require('should');
+const sinon = require('sinon');
+
+const cookies = request.cookies;
+const Assertion = require('../lib/cookies/Assertion');
+
+const secrets = ['one', 'a', 'two', 'b'];
+
+describe('cookie', function () {
+  it('returns Assertion function', function (done) {
+    const assertion = Assertion();
+    const cookiesAssertion = cookies();
+
+    should(cookiesAssertion).be.eql(assertion);
+
+    done();
+  });
+
+  it('runs single asserts', function (done) {
+    let assertion = sinon.stub();
+
+    const app = express();
+
+    app.get('/', function (req, res) {
+      res.send();
+    });
+
+    request(app)
+      .get('/')
+      .set('Cookie', 'control=placebo')
+      .expect(cookies(null, assertion))
+      .end(function () {
+        sinon.assert.calledOnce(assertion);
+        done();
+      });
+  });
+
+  it('runs multiple asserts', function (done) {
+    let assertionA = sinon.stub();
+    let assertionB = sinon.stub();
+
+    let asserts = [
+      assertionA,
+      assertionB
+    ];
+
+    const app = express();
+
+    app.get('/', function (req, res) {
+      res.send();
+    });
+
+    request(app)
+      .get('/')
+      .set('Cookie', 'control=placebo')
+      .expect(cookies(null, asserts))
+      .end(function () {
+        sinon.assert.calledOnce(assertionA);
+        sinon.assert.calledOnce(assertionB);
+        done();
+      });
+  });
+
+  describe('.set', function () {
+    it('asserts true if signed cookie is set and options are set', function (done) {
+      const app = express();
+
+      app.use(cookieParser(secrets));
+
+      app.get('/', function (req, res) {
+        res.cookie('substance', 'active', {
+          domain: 'domain.com',
+          path: '/',
+          expires: new Date(),
+          secure: 1,
+          httpOnly: true,
+          signed: true
+        });
+        res.send();
+      });
+
+      request(app)
+        .get('/')
+        .set('Cookie', 'control=placebo')
+        .expect(function (res) {
+          const assertion = cookies.set({
+            name: 'substance',
+            options: ['domain', 'path', 'expires', 'secure', 'httponly']
+          });
+
+          should(function () {
+            assertion(res);
+          }).not.throw();
+        })
+        .end(done);
+    });
+
+    it('asserts true if unsigned cookie is set and options are set', function (done) {
+      const app = express();
+
+      app.use(cookieParser(secrets));
+
+      app.get('/', function (req, res) {
+        res.cookie('substance', 'active', {
+          domain: 'domain.com', path: '/', expires: new Date(), secure: 1, httpOnly: true
+        });
+        res.send();
+      });
+
+      request(app)
+        .get('/')
+        .set('Cookie', 'control=placebo')
+        .expect(function (res) {
+          const assertion = cookies.set({
+            name: 'substance',
+            options: ['domain', 'path', 'expires', 'secure', 'httponly']
+          });
+
+          should(function () {
+            assertion(res);
+          }).not.throw();
+        })
+        .end(done);
+    });
+
+    it('asserts false if unsigned cookie is set but option was NOT set', function (done) {
+      const app = express();
+
+      app.use(cookieParser(secrets));
+
+      app.get('/', function (req, res) {
+        res.cookie('substance', 'active', {
+          domain: 'domain.com', path: '/', expires: new Date(), secure: 1
+        });
+        res.send();
+      });
+
+      request(app)
+        .get('/')
+        .set('Cookie', 'control=placebo')
+        .expect(function (res) {
+          const assertion = cookies.set({
+            name: 'substance',
+            options: ['domain', 'path', 'expires', 'secure', 'httponly']
+          });
+
+          should(function () {
+            assertion(res);
+          }).throw();
+        })
+        .end(done);
+    });
+  });
+
+  describe('.reset', function () {
+    it('asserts true if signed cookie is set and was already set', function (done) {
+      const app = express();
+
+      app.use(cookieParser(secrets));
+
+      app.get('/', function (req, res) {
+        res.cookie('substance', 'active', {
+          domain: 'domain.com',
+          path: '/',
+          expires: new Date(),
+          secure: 1,
+          httpOnly: true,
+          signed: true
+        });
+        res.send();
+      });
+
+      request(app)
+        .get('/')
+        .set('Cookie', 'control=placebo;substance=active')
+        .expect(function (res) {
+          const assertion = cookies.reset({
+            name: 'substance'
+          });
+
+          should(function () {
+            assertion(res);
+          }).not.throw();
+        })
+        .end(done);
+    });
+
+    it('asserts false if cookie is NOT set', function (done) {
+      const app = express();
+
+      app.use(cookieParser(secrets));
+
+      app.get('/', function (req, res) {
+        res.send();
+      });
+
+      request(app)
+        .get('/')
+        .set('Cookie', 'control=placebo')
+        .expect(function (res) {
+          const assertion = cookies.reset({
+            name: 'substance'
+          });
+
+          should(function () {
+            assertion(res);
+          }).throw();
+        })
+        .end(done);
+    });
+  });
+
+  describe('.new', function () {
+    it('asserts true if signed cookie is set and was NOT already set', function (done) {
+      const app = express();
+
+      app.use(cookieParser(secrets));
+
+      app.get('/', function (req, res) {
+        res.cookie('substance', 'active', {
+          domain: 'domain.com',
+          path: '/',
+          expires: new Date(),
+          secure: 1,
+          httpOnly: true,
+          signed: true
+        });
+        res.send();
+      });
+
+      request(app)
+        .get('/')
+        .set('Cookie', 'control=placebo')
+        .expect(function (res) {
+          const assertion = cookies.new({
+            name: 'substance'
+          });
+
+          should(function () {
+            assertion(res);
+          }).not.throw();
+        })
+        .end(done);
+    });
+
+    it('asserts false if signed cookie is set but was already set', function (done) {
+      const app = express();
+
+      app.use(cookieParser(secrets));
+
+      app.get('/', function (req, res) {
+        res.cookie('substance', 'active', {
+          domain: 'domain.com',
+          path: '/',
+          expires: new Date(),
+          secure: 1,
+          httpOnly: true,
+          signed: true
+        });
+        res.send();
+      });
+
+      request(app)
+        .get('/')
+        .set('Cookie', 'control=placebo;substance=active')
+        .expect(function (res) {
+          const assertion = cookies.new({
+            name: 'substance'
+          });
+
+          should(function () {
+            assertion(res);
+          }).throw();
+        })
+        .end(done);
+    });
+
+    it('asserts false if cookie is NOT set', function (done) {
+      const app = express();
+
+      app.use(cookieParser(secrets));
+
+      app.get('/', function (req, res) {
+        res.send();
+      });
+
+      request(app)
+        .get('/')
+        .set('Cookie', 'control=placebo')
+        .expect(function (res) {
+          const assertion = cookies.new({
+            name: 'substance'
+          });
+
+          should(function () {
+            assertion(res);
+          }).throw();
+        })
+        .end(done);
+    });
+  });
+
+  describe('.renew', function () {
+    it('asserts true if set cookie expires is greater than expects cookie', function (done) {
+      const expires = new Date();
+      const expiresRenewed = new Date(expires.getTime() + 5000); // using 5000 ms for date precision safety
+
+      const app = express();
+
+      app.use(cookieParser(secrets));
+
+      app.get('/', function (req, res) {
+        res.cookie('substance', 'active', {
+          domain: 'domain.com',
+          path: '/',
+          expires: expiresRenewed,
+          secure: 1,
+          httpOnly: true,
+          signed: true
+        });
+        res.send();
+      });
+
+      request(app)
+        .get('/')
+        .set('Cookie', 'control=placebo;substance=active')
+        .expect(function (res) {
+          const assertion = cookies.renew({
+            name: 'substance',
+            options: {
+              expires: expires.toUTCString()
+            }
+          });
+
+          should(function () {
+            assertion(res);
+          }).not.throw();
+        })
+        .end(done);
+    });
+
+    it('asserts false if set cookie expires is less than expects cookie', function (done) {
+      const expires = new Date();
+      const expiresRenewed = new Date(expires.getTime() - 5000); // using 5000 ms for date precision safety
+
+      const app = express();
+
+      app.use(cookieParser(secrets));
+
+      app.get('/', function (req, res) {
+        res.cookie('substance', 'active', {
+          domain: 'domain.com',
+          path: '/',
+          expires: expiresRenewed,
+          secure: 1,
+          httpOnly: true,
+          signed: true
+        });
+        res.send();
+      });
+
+      request(app)
+        .get('/')
+        .set('Cookie', 'control=placebo;substance=active')
+        .expect(function (res) {
+          const assertion = cookies.renew({
+            name: 'substance',
+            options: {
+              expires: expires.toUTCString()
+            }
+          });
+
+          should(function () {
+            assertion(res);
+          }).throw();
+        })
+        .end(done);
+    });
+
+    it('asserts false if set cookie expires is equal to expects cookie', function (done) {
+      const expires = new Date();
+      const expiresRenewed = expires;
+
+      const app = express();
+
+      app.use(cookieParser(secrets));
+
+      app.get('/', function (req, res) {
+        res.cookie('substance', 'active', {
+          domain: 'domain.com',
+          path: '/',
+          expires: expiresRenewed,
+          secure: 1,
+          httpOnly: true,
+          signed: true
+        });
+        res.send();
+      });
+
+      request(app)
+        .get('/')
+        .set('Cookie', 'control=placebo;substance=active')
+        .expect(function (res) {
+          const assertion = cookies.renew({
+            name: 'substance',
+            options: {
+              expires: expires.toUTCString()
+            }
+          });
+
+          should(function () {
+            assertion(res);
+          }).throw();
+        })
+        .end(done);
+    });
+
+    it('asserts true if set cookie max-age is greater than expects cookie', function (done) {
+      const maxAge = 60;
+      const maxAgeRenewed = (maxAge + 1) * 1000; // res.cookie expects ms
+
+      const app = express();
+
+      app.use(cookieParser(secrets));
+
+      app.get('/', function (req, res) {
+        res.cookie('substance', 'active', {
+          domain: 'domain.com',
+          path: '/',
+          maxAge: maxAgeRenewed,
+          secure: 1,
+          httpOnly: true,
+          signed: true
+        });
+        res.send();
+      });
+
+      request(app)
+        .get('/')
+        .set('Cookie', 'control=placebo;substance=active')
+        .expect(function (res) {
+          const assertion = cookies.renew({
+            name: 'substance',
+            options: {
+              'max-age': maxAge
+            }
+          });
+
+          should(function () {
+            assertion(res);
+          }).not.throw();
+        })
+        .end(done);
+    });
+
+    it('asserts false if set cookie max-age is less than expects cookie', function (done) {
+      const maxAge = 120;
+      const maxAgeRenewed = (maxAge - 1) * 1000; // res.cookie expects ms
+
+      const app = express();
+
+      app.use(cookieParser(secrets));
+
+      app.get('/', function (req, res) {
+        res.cookie('substance', 'active', {
+          domain: 'domain.com',
+          path: '/',
+          maxAge: maxAgeRenewed,
+          secure: 1,
+          httpOnly: true,
+          signed: true
+        });
+        res.send();
+      });
+
+      request(app)
+        .get('/')
+        .set('Cookie', 'control=placebo;substance=active')
+        .expect(function (res) {
+          const assertion = cookies.renew({
+            name: 'substance',
+            options: {
+              'max-age': maxAge
+            }
+          });
+
+          should(function () {
+            assertion(res);
+          }).throw();
+        })
+        .end(done);
+    });
+
+    it('asserts false if set cookie max-age is equal to expects cookie', function (done) {
+      const maxAge = 60000;
+
+      const app = express();
+
+      app.use(cookieParser(secrets));
+
+      app.get('/', function (req, res) {
+        res.cookie('substance', 'active', {
+          domain: 'domain.com', path: '/', maxAge: maxAge, secure: 1, httpOnly: true, signed: true
+        });
+        res.send();
+      });
+
+      request(app)
+        .get('/')
+        .set('Cookie', 'control=placebo;substance=active')
+        .expect(function (res) {
+          const assertion = cookies.renew({
+            name: 'substance',
+            options: {
+              'max-age': maxAge
+            }
+          });
+
+          should(function () {
+            assertion(res);
+          }).throw();
+        })
+        .end(done);
+    });
+
+    it('asserts false if cookie is NOT set', function (done) {
+      const expires = new Date();
+
+      const app = express();
+
+      app.use(cookieParser(secrets));
+
+      app.get('/', function (req, res) {
+        res.send();
+      });
+
+      request(app)
+        .get('/')
+        .set('Cookie', 'control=placebo')
+        .expect(function (res) {
+          const assertion = cookies.renew({
+            name: 'substance',
+            options: {
+              expires: expires.toUTCString()
+            }
+          });
+
+          should(function () {
+            assertion(res);
+          }).throw();
+        })
+        .end(done);
+    });
+  });
+
+  describe('.contain', function () {
+    it('asserts true if cookie contains expected options', function (done) {
+      const expires = new Date();
+
+      const app = express();
+
+      app.use(cookieParser(secrets));
+
+      app.get('/', function (req, res) {
+        res.cookie('substance', 'active', {
+          domain: 'domain.com', path: '/', expires: expires, secure: 1, httpOnly: true, signed: true
+        });
+        res.send();
+      });
+
+      request(app)
+        .get('/')
+        .set('Cookie', 'control=placebo')
+        .expect(function (res) {
+          const assertion = cookies(secrets).contain({
+            name: 'substance',
+            value: 'active',
+            options: {
+              domain: 'domain.com',
+              path: '/',
+              expires: expires.toUTCString(),
+              secure: true,
+              httponly: true
+            }
+          });
+
+          should(function () {
+            assertion(res);
+          }).not.throw();
+        })
+        .end(done);
+    });
+
+    it('asserts false if cookie does NOT contain expected options', function (done) {
+      const expires = new Date();
+
+      const app = express();
+
+      app.use(cookieParser(secrets));
+
+      app.get('/', function (req, res) {
+        res.cookie('substance', 'active', {
+          domain: 'domain.com', path: '/', expires: expires, secure: 1, httpOnly: true, signed: true
+        });
+        res.send();
+      });
+
+      request(app)
+        .get('/')
+        .set('Cookie', 'control=placebo')
+        .expect(function (res) {
+          const assertion = cookies(secrets).contain({
+            name: 'substance',
+            value: 'active',
+            options: {
+              domain: 'domain.com',
+              path: '/',
+              expires: expires.toUTCString(),
+              'max-age': 60,
+              secure: true,
+              httponly: true
+            }
+          });
+
+          should(function () {
+            assertion(res);
+          }).throw();
+        })
+        .end(done);
+    });
+
+    it('handles type conversion for max-age', function (done) {
+      var app = express();
+
+      app.use(cookieParser(secrets));
+
+      app.get('/', function (req, res) {
+        res.cookie('substance', 'active', { domain: 'domain.com', maxAge: 60000 });
+        res.send();
+      });
+
+      request(app)
+        .get('/')
+        .set('Cookie', 'control=placebo')
+        .expect(function (res) {
+          var assertion = cookies(secrets).contain({
+            name: 'substance',
+            value: 'active',
+            options: {
+              domain: 'domain.com',
+              'max-age': 60
+            }
+          });
+
+          should(function () {
+            assertion(res);
+          }).not.throw();
+        })
+        .end(done);
+    });
+
+    it('allows any value if omitted from expects object', function (done) {
+      var app = express();
+      app.use(cookieParser(secrets));
+      app.get('/', function (req, res) {
+        res.cookie('substance', 'active', { domain: 'domain.com' });
+        res.send();
+      });
+
+      request(app)
+        .get('/')
+        .set('Cookie', 'control=placebo')
+        .expect(function (res) {
+          var assertion = cookies(secrets).contain({
+            name: 'substance',
+            options: {
+              domain: 'domain.com'
+            }
+          });
+
+          should(function () {
+            assertion(res);
+          }).not.throw();
+        })
+        .end(done);
+    });
+
+    it('asserts false if cookie does NOT exist', function (done) {
+      const expires = new Date();
+
+      const app = express();
+
+      app.use(cookieParser(secrets));
+
+      app.get('/', function (req, res) {
+        res.send();
+      });
+
+      request(app)
+        .get('/')
+        .set('Cookie', 'control=placebo')
+        .expect(function (res) {
+          const assertion = cookies(secrets).contain({
+            name: 'substance',
+            value: 'active',
+            options: {
+              domain: 'domain.com',
+              path: '/',
+              expires: expires.toUTCString(),
+              secure: true,
+              httponly: true
+            }
+          });
+
+          should(function () {
+            assertion(res);
+          }).throw();
+        })
+        .end(done);
+    });
+  });
+
+  describe('.not', function () {
+    describe('.set', function () {
+      it('asserts true if cookie is NOT set', function (done) {
+        const app = express();
+
+        app.use(cookieParser(secrets));
+
+        app.get('/', function (req, res) {
+          res.send();
+        });
+
+        request(app)
+          .get('/')
+          .set('Cookie', 'control=placebo')
+          .expect(function (res) {
+            const assertion = cookies.not('set', {
+              name: 'substance'
+            });
+
+            should(function () {
+              assertion(res);
+            }).not.throw();
+          })
+          .end(done);
+      });
+
+      it('asserts true if unsigned cookie is set but option is NOT set', function (done) {
+        const expires = new Date();
+
+        const app = express();
+
+        app.use(cookieParser(secrets));
+
+        app.get('/', function (req, res) {
+          res.cookie('substance', 'active', {
+            domain: 'domain.com', path: '/', expires: expires, secure: 1
+          });
+          res.send();
+        });
+
+        request(app)
+          .get('/')
+          .set('Cookie', 'control=placebo')
+          .expect(function (res) {
+            const assertion = cookies.not('set', {
+              substance: 'active',
+              name: 'substance',
+              options: ['httponly']
+            });
+
+            should(function () {
+              assertion(res);
+            }).not.throw();
+          })
+          .end(done);
+      });
+
+      it('asserts false if cookie is set', function (done) {
+        const expires = new Date();
+
+        const app = express();
+
+        app.use(cookieParser(secrets));
+
+        app.get('/', function (req, res) {
+          res.cookie('substance', 'active', {
+            domain: 'domain.com', path: '/', expires: expires, secure: 1
+          });
+          res.send();
+        });
+
+        request(app)
+          .get('/')
+          .set('Cookie', 'control=placebo')
+          .expect(function (res) {
+            const assertion = cookies.not('set', {
+              name: 'substance'
+            });
+
+            should(function () {
+              assertion(res);
+            }).throw();
+          })
+          .end(done);
+      });
+    });
+
+    describe('.reset', function () {
+      it('asserts true if cookie is NOT set but was already set', function (done) {
+        const app = express();
+
+        app.use(cookieParser(secrets));
+
+        app.get('/', function (req, res) {
+          res.send();
+        });
+
+        request(app)
+          .get('/')
+          .set('Cookie', 'control=placebo;substance=active')
+          .expect(function (res) {
+            const assertion = cookies.not('reset', {
+              name: 'substance'
+            });
+
+            should(function () {
+              assertion(res);
+            }).not.throw();
+          })
+          .end(done);
+      });
+
+      it('asserts false if unsigned cookie is set but was already set', function (done) {
+        const expires = new Date();
+
+        const app = express();
+
+        app.use(cookieParser(secrets));
+
+        app.get('/', function (req, res) {
+          res.cookie('substance', 'active', {
+            domain: 'domain.com', path: '/', expires: expires, secure: 1
+          });
+          res.send();
+        });
+
+        request(app)
+          .get('/')
+          .set('Cookie', 'control=placebo;substance=active')
+          .expect(function (res) {
+            const assertion = cookies.not('reset', {
+              name: 'substance'
+            });
+
+            should(function () {
+              assertion(res);
+            }).throw();
+          })
+          .end(done);
+      });
+    });
+
+    describe('.new', function () {
+      it('asserts true if cookie is set and was already set', function (done) {
+        const expires = new Date();
+
+        const app = express();
+
+        app.use(cookieParser(secrets));
+
+        app.get('/', function (req, res) {
+          res.cookie('substance', 'active', {
+            domain: 'domain.com',
+            path: '/',
+            expires: expires,
+            secure: 1,
+            httpOnly: true,
+            signed: true
+          });
+          res.send();
+        });
+
+        request(app)
+          .get('/')
+          .set('Cookie', 'control=placebo;substance=active')
+          .expect(function (res) {
+            const assertion = cookies.not('new', {
+              name: 'substance'
+            });
+
+            should(function () {
+              assertion(res);
+            }).not.throw();
+          })
+          .end(done);
+      });
+
+      it('asserts false if cookie is set and was NOT already set', function (done) {
+        const expires = new Date();
+
+        const app = express();
+
+        app.use(cookieParser(secrets));
+
+        app.get('/', function (req, res) {
+          res.cookie('substance', 'active', {
+            domain: 'domain.com',
+            path: '/',
+            expires: expires,
+            secure: 1,
+            httpOnly: true,
+            signed: true
+          });
+          res.send();
+        });
+
+        request(app)
+          .get('/')
+          .set('Cookie', 'control=placebo')
+          .expect(function (res) {
+            const assertion = cookies.not('new', {
+              name: 'substance'
+            });
+
+            should(function () {
+              assertion(res);
+            }).throw();
+          })
+          .end(done);
+      });
+    });
+
+    describe('.renew', function () {
+      it('asserts true if set cookie expires is equal to expects cookie', function (done) {
+        const expires = new Date();
+
+        const app = express();
+
+        app.use(cookieParser(secrets));
+
+        app.get('/', function (req, res) {
+          res.cookie('substance', 'active', {
+            domain: 'domain.com',
+            path: '/',
+            expires: expires,
+            secure: 1,
+            httpOnly: true,
+            signed: true
+          });
+          res.send();
+        });
+
+        request(app)
+          .get('/')
+          .set('Cookie', 'control=placebo;substance=active')
+          .expect(function (res) {
+            const assertion = cookies.not('renew', {
+              name: 'substance',
+              options: {
+                expires: expires.toUTCString()
+              }
+            });
+
+            should(function () {
+              assertion(res);
+            }).not.throw();
+          })
+          .end(done);
+      });
+
+      it('asserts true if set cookie expires is less than expects cookie', function (done) {
+        const expires = new Date();
+        const expiresRenewed = new Date(expires.getTime() - 5000); // using 5000 ms for date precision safety
+
+        const app = express();
+
+        app.use(cookieParser(secrets));
+
+        app.get('/', function (req, res) {
+          res.cookie('substance', 'active', {
+            domain: 'domain.com',
+            path: '/',
+            expires: expiresRenewed,
+            secure: 1,
+            httpOnly: true,
+            signed: true
+          });
+          res.send();
+        });
+
+        request(app)
+          .get('/')
+          .set('Cookie', 'control=placebo;substance=active')
+          .expect(function (res) {
+            const assertion = cookies.not('renew', {
+              name: 'substance',
+              options: {
+                expires: expires.toUTCString()
+              }
+            });
+
+            should(function () {
+              assertion(res);
+            }).not.throw();
+          })
+          .end(done);
+      });
+
+      it('asserts false if set cookie expires is greater than expects cookie', function (done) {
+        const expires = new Date();
+        const expiresRenewed = new Date(expires.getTime() + 5000); // using 5000 ms for date precision safety
+
+        const app = express();
+
+        app.use(cookieParser(secrets));
+
+        app.get('/', function (req, res) {
+          res.cookie('substance', 'active', {
+            domain: 'domain.com',
+            path: '/',
+            expires: expiresRenewed,
+            secure: 1,
+            httpOnly: true,
+            signed: true
+          });
+          res.send();
+        });
+
+        request(app)
+          .get('/')
+          .set('Cookie', 'control=placebo;substance=active')
+          .expect(function (res) {
+            const assertion = cookies.not('renew', {
+              name: 'substance',
+              options: {
+                expires: expires.toUTCString()
+              }
+            });
+
+            should(function () {
+              assertion(res);
+            }).throw();
+          })
+          .end(done);
+      });
+
+      it('asserts true if set cookie max-age is same as expects cookie', function (done) {
+        const maxAge = 60;
+        const maxAgeRenewed = maxAge * 1000; // res.cookie expects ms
+
+        const app = express();
+
+        app.use(cookieParser(secrets));
+
+        app.get('/', function (req, res) {
+          res.cookie('substance', 'active', {
+            domain: 'domain.com',
+            path: '/',
+            maxAge: maxAgeRenewed,
+            secure: 1,
+            httpOnly: true,
+            signed: true
+          });
+          res.send();
+        });
+
+        request(app)
+          .get('/')
+          .set('Cookie', 'control=placebo;substance=active')
+          .expect(function (res) {
+            const assertion = cookies.not('renew', {
+              name: 'substance',
+              options: {
+                'max-age': maxAge
+              }
+            });
+
+            should(function () {
+              assertion(res);
+            }).not.throw();
+          })
+          .end(done);
+      });
+
+      it('asserts true if set cookie max-age is less than expects cookie', function (done) {
+        const maxAge = 60;
+        const maxAgeRenewed = (maxAge - 1) * 1000; // res.cookie expects ms
+
+        const app = express();
+
+        app.use(cookieParser(secrets));
+
+        app.get('/', function (req, res) {
+          res.cookie('substance', 'active', {
+            domain: 'domain.com',
+            path: '/',
+            maxAge: maxAgeRenewed,
+            secure: 1,
+            httpOnly: true,
+            signed: true
+          });
+          res.send();
+        });
+
+        request(app)
+          .get('/')
+          .set('Cookie', 'control=placebo;substance=active')
+          .expect(function (res) {
+            const assertion = cookies.not('renew', {
+              name: 'substance',
+              options: {
+                'max-age': maxAge
+              }
+            });
+
+            should(function () {
+              assertion(res);
+            }).not.throw();
+          })
+          .end(done);
+      });
+
+      it('asserts false if set cookie max-age is greater than expires cookie', function (done) {
+        const maxAge = 60;
+        const maxAgeRenewed = (maxAge + 1) * 1000; // res.cookie expects ms
+
+        const app = express();
+
+        app.use(cookieParser(secrets));
+
+        app.get('/', function (req, res) {
+          res.cookie('substance', 'active', {
+            domain: 'domain.com',
+            path: '/',
+            maxAge: maxAgeRenewed,
+            secure: 1,
+            httpOnly: true,
+            signed: true
+          });
+          res.send();
+        });
+
+        request(app)
+          .get('/')
+          .set('Cookie', 'control=placebo;substance=active')
+          .expect(function (res) {
+            const assertion = cookies.not('renew', {
+              name: 'substance',
+              options: {
+                'max-age': maxAge
+              }
+            });
+
+            should(function () {
+              assertion(res);
+            }).throw();
+          })
+          .end(done);
+      });
+    });
+
+    describe('.contain', function () {
+      it('asserts true if cookie does NOT contain option', function (done) {
+        const expires = new Date();
+
+        const app = express();
+
+        app.use(cookieParser(secrets));
+
+        app.get('/', function (req, res) {
+          res.cookie('substance', 'active', {
+            domain: 'domain.com',
+            path: '/',
+            expires: expires,
+            maxAge: 60000,
+            secure: 1,
+            httpOnly: true
+          });
+          res.send();
+        });
+
+        request(app)
+          .get('/')
+          .set('Cookie', 'control=placebo')
+          .expect(function (res) {
+            const assertion = cookies(secrets).not('contain', {
+              name: 'substance',
+              value: 'active'
+            });
+
+            should(function () {
+              assertion(res);
+            }).not.throw();
+          })
+          .end(done);
+      });
+
+      it('asserts false if cookie contains expected options', function (done) {
+        const expires = new Date();
+
+        const app = express();
+
+        app.use(cookieParser(secrets));
+
+        app.get('/', function (req, res) {
+          res.cookie('substance', 'active', {
+            domain: 'domain.com',
+            path: '/',
+            expires: expires,
+            secure: 1,
+            httpOnly: true,
+            signed: true
+          });
+          res.send();
+        });
+
+        request(app)
+          .get('/')
+          .set('Cookie', 'control=placebo')
+          .expect(function (res) {
+            const assertion = cookies(secrets).not('contain', {
+              name: 'substance',
+              value: 'active',
+              options: {
+                domain: 'domain.com',
+                path: '/',
+                expires: expires.toUTCString(),
+                secure: true,
+                httponly: true
+              }
+            });
+
+            should(function () {
+              assertion(res);
+            }).throw();
+          })
+          .end(done);
+      });
+    });
+  });
+
+  describe('README example', function () {
+    it('should work correctly', function () {
+      // setup super-test
+      // NOTE: uncomment lines below when copying into README
+      // const request = require('supertest');
+      // const express = require('express');
+      // const cookies = request.cookies;
+
+      // setup express test service
+      const app = express();
+
+      app.get('/users', function(req, res) {
+        res.cookie('alpha', 'one', { domain: 'domain.com', path: '/', httpOnly: true });
+        res.send(200, { name: 'tobi' });
+      });
+
+      // test request to service
+      request(app)
+        .get('/users')
+        .expect('Content-Type', /json/)
+        .expect('Content-Length', '15')
+        .expect(200)
+        // assert 'alpha' cookie is set with domain, path, and httpOnly options
+        .expect(cookies.set({ name: 'alpha', options: ['domain', 'path', 'httponly'] }))
+        // assert 'bravo' cookie is NOT set
+        .expect(cookies.not('set', { name: 'bravo' }))
+        .end(function(err, res) {
+          if (err) {
+            throw err;
+          }
+        });
+    });
+  });
+});


### PR DESCRIPTION
Add a convenient workflow for running assertions on cookie headers returned by the server. This code is largely copied from Gregory Langlais' package [`expect-cookies`](https://github.com/gregl83/expect-cookies) (MIT License).

Implements #855.

Example usage:
```js
const request = require('supertest');
const cookies = request.cookies;

request(app)
  .get('/users')
  .expect('Content-Type', /json/)
  .expect('Content-Length', '15')
  .expect(200)
  // assert 'alpha' cookie is set with domain, path, and httpOnly options
  .expect(cookies.set({ name: 'alpha', options: ['domain', 'path', 'httponly'] }))
  // assert 'bravo' cookie is NOT set
  .expect(cookies.not('set', { name: 'bravo' }))
  .end(function(err, res) {
    if (err) {
      throw err;
    }
  });
```

Supports:
- `.set` - Assert that cookie and options are set.
- `.reset` - Assert that cookie is set and was already set (in request headers).
- `.new` - Assert that cookie is set and was NOT already set (NOT in request headers).
- `.renew` - Assert that cookie is set with a strictly greater `expires` or `max-age` than the given value.
- `.contain` - Assert that cookie is set with value and contains options.
- `.not` - Call any cookies assertion method with "assert true" modifier set to `false`.

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
